### PR TITLE
Remove supplier role from User model

### DIFF
--- a/user/models.py
+++ b/user/models.py
@@ -13,7 +13,6 @@ class User(AbstractUser):
         ('DELIVERY_MANAGER','Delivery Manager'),
         ('RECOVERY_OFFICER','Recovery Officer'),
         ('INVESTOR','Investor'),
-        ('supplier', 'Supplier'),
     )
     role = models.CharField(max_length=30, choices=ROLES, default='CUSTOMER')
 


### PR DESCRIPTION
## Summary
- remove `supplier` from backend `User` role choices to keep roles aligned with the PWA

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688fb253452c832981d0f1fa169cbb42