### PR TITLE
Expose rate and stock aliases for inventory models

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -4,7 +4,7 @@ from .models import Product, Party, Batch, StockMovement
 
 @admin.register(Product)
 class ProductAdmin(admin.ModelAdmin):
-    list_display = ('name', 'company', 'trade_price', 'retail_price', 'disable_sale_purchase')
+    list_display = ('name', 'company', 'rate', 'retail_price', 'stock', 'disable_sale_purchase')
     search_fields = ('name', 'barcode')
     list_filter = ('company', 'group', 'distributor')
 
@@ -16,7 +16,7 @@ class PartyAdmin(admin.ModelAdmin):
 
 @admin.register(Batch)
 class BatchAdmin(admin.ModelAdmin):
-    list_display = ('product', 'batch_number', 'expiry_date', 'quantity')
+    list_display = ('product', 'batch_number', 'expiry_date', 'stock', 'rate')
     list_filter = ('product', 'expiry_date')
     search_fields = ('batch_number', 'product__name')
 

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -14,6 +14,20 @@ class Product(models.Model):
     fed_tax_ratio = models.DecimalField(max_digits=5, decimal_places=2)
     disable_sale_purchase = models.BooleanField(default=False)
 
+    @property
+    def rate(self):
+        """Alias to the product's trade price for unified naming."""
+        return self.trade_price
+
+    @rate.setter
+    def rate(self, value):
+        self.trade_price = value
+
+    @property
+    def stock(self):
+        """Total available quantity across all batches."""
+        return self.batch_set.aggregate(total=models.Sum('quantity'))['total'] or 0
+
     def __str__(self):
         return self.name
 
@@ -27,6 +41,24 @@ class Batch(models.Model):
     sale_price = models.DecimalField(max_digits=10, decimal_places=2)
     quantity = models.PositiveIntegerField()
     warehouse = models.ForeignKey('setting.Warehouse', on_delete=models.CASCADE)  # optional but recommended
+
+    @property
+    def rate(self):
+        """Alias to sale price using common terminology."""
+        return self.sale_price
+
+    @rate.setter
+    def rate(self, value):
+        self.sale_price = value
+
+    @property
+    def stock(self):
+        """Expose quantity as stock for clarity."""
+        return self.quantity
+
+    @stock.setter
+    def stock(self, value):
+        self.quantity = value
 
     def __str__(self):
         return f"{self.product.name} - {self.batch_number}"


### PR DESCRIPTION
## Summary
- provide `rate` and `stock` properties on `Product` and `Batch`
- surface aliases in admin list displays

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688fb0dc33248329bef9dc3d670f2415