### PR TITLE
Expose Party contact and location fields in admin

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -1,6 +1,7 @@
 # inventory/admin.py
 from django.contrib import admin
 from .models import Product, Party, Batch, StockMovement
+from .forms import PartyForm
 
 @admin.register(Product)
 class ProductAdmin(admin.ModelAdmin):
@@ -10,7 +11,17 @@ class ProductAdmin(admin.ModelAdmin):
 
 @admin.register(Party)
 class PartyAdmin(admin.ModelAdmin):
-    list_display = ('name', 'party_type', 'phone', 'email', 'category', 'latitude', 'longitude', 'price_list')
+    form = PartyForm
+    list_display = (
+        'name',
+        'party_type',
+        'phone',
+        'email',
+        'category',
+        'latitude',
+        'longitude',
+        'price_list',
+    )
     search_fields = ('name', 'phone', 'email', 'category')
     list_filter = ('party_type',)
 

--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -1,0 +1,26 @@
+from django import forms
+from .models import Party
+
+
+class PartyForm(forms.ModelForm):
+    """Form for creating and updating Party instances."""
+
+    class Meta:
+        model = Party
+        fields = [
+            'name',
+            'address',
+            'phone',
+            'email',
+            'party_type',
+            'category',
+            'city',
+            'area',
+            'latitude',
+            'longitude',
+            'price_list',
+            'proprietor',
+            'license_no',
+            'license_expiry',
+            'credit_limit',
+        ]


### PR DESCRIPTION
## Summary
- add PartyForm to manage contact and location fields
- hook PartyAdmin to PartyForm and display email, category, latitude, longitude, and price list

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688fb177a1148329bb3595b373c37d7f