### PR TITLE
Add task model for employee assignments

### DIFF
--- a/hr/models.py
+++ b/hr/models.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
 from user.models import User
 
 class Employee(models.Model):
@@ -127,3 +129,44 @@ class PayrollSlip(models.Model):
 
     def __str__(self):
         return f"{self.employee.name} - {self.month.strftime('%B %Y')}"
+
+
+class Task(models.Model):
+    """General task assigned to an employee."""
+
+    STATUS_CHOICES = [
+        ("PENDING", "Pending"),
+        ("IN_PROGRESS", "In Progress"),
+        ("COMPLETED", "Completed"),
+        ("CANCELLED", "Cancelled"),
+    ]
+
+    assignment = models.CharField(max_length=255)
+    assigned_to = models.ForeignKey(
+        Employee, related_name="tasks", on_delete=models.CASCADE
+    )
+    assigned_by = models.ForeignKey(
+        Employee,
+        related_name="assigned_tasks",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+    due_date = models.DateField()
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="PENDING")
+
+    # Optional links
+    party = models.ForeignKey(
+        "inventory.Party", on_delete=models.SET_NULL, null=True, blank=True
+    )
+    invoice_content_type = models.ForeignKey(
+        ContentType, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    invoice_object_id = models.PositiveIntegerField(null=True, blank=True)
+    invoice = GenericForeignKey("invoice_content_type", "invoice_object_id")
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self) -> str:
+        return self.assignment


### PR DESCRIPTION
## Summary
- add Task model to HR for tracking assignments, due dates, and status
- allow optional linkage to parties or invoices using generic relation

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688fb17c44f0832998d5e9645fa065f0