### PR TITLE
feat: versioned service worker caching

### DIFF
--- a/Frontend-PWD/README.md
+++ b/Frontend-PWD/README.md
@@ -12,3 +12,20 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Service worker cache
+
+The service worker (`sw.js`) precaches built assets using the `asset-manifest.json`
+file emitted during `npm run build`. Cache names include a version string (see
+`CACHE_VERSION` in `sw.js`) and old caches are purged on activation.
+
+### Updating cached assets
+
+1. Build the app: `npm run build` – this generates `dist/asset-manifest.json`.
+2. Deploy the contents of `dist/` (including `asset-manifest.json`) to your
+   hosting environment.
+3. Bump `CACHE_VERSION` in `sw.js` whenever you need to force clients to refresh
+   cached resources.
+
+External CDN resources are cached at runtime and refreshed whenever a network
+response is available, preventing stale third‑party assets.

--- a/Frontend-PWD/package.json
+++ b/Frontend-PWD/package.json
@@ -13,7 +13,8 @@
     "react": "^19.1.1",
     "@google/genai": "^1.11.0",
     "recharts": "^3.1.0",
-    "qrcode.react": "^3.1.0"
+    "qrcode.react": "^3.1.0",
+    "react-is": "^19.1.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/Frontend-PWD/vite.config.ts
+++ b/Frontend-PWD/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      build: {
+        manifest: 'asset-manifest.json'
       }
     };
 });


### PR DESCRIPTION
## Summary
- precache built assets using a generated `asset-manifest.json`
- separate runtime cache for CDN resources
- document cache versioning strategy and build manifest in README
- configure Vite to output `asset-manifest.json` and add missing `react-is` dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fc5f590408329a0f6659323a71c8d