### PR TITLE
Implement user auth endpoints and integrate frontend login flow

### DIFF
--- a/Frontend-PWD/App.tsx
+++ b/Frontend-PWD/App.tsx
@@ -37,12 +37,13 @@ import InvestorDashboard from './components/InvestorDashboard';
 import Investors from './components/Investors';
 import InvestorLedger from './components/InvestorLedger';
 import ROUTES from './routes';
+import { getCurrentUser, logout as logoutService } from './services/auth';
 
 const App: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [isSidebarOpen, setSidebarOpen] = useState(false);
-  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [currentUser, setCurrentUser] = useState<User | null>(() => getCurrentUser());
 
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
   const [saleInvoiceToEdit, setSaleInvoiceToEdit] = useState<Order | null>(null);
@@ -64,6 +65,7 @@ const App: React.FC = () => {
   };
 
   const handleLogout = () => {
+    logoutService();
     setCurrentUser(null);
     setCurrentPage('login');
   };

--- a/Frontend-PWD/components/CustomerDashboard.tsx
+++ b/Frontend-PWD/components/CustomerDashboard.tsx
@@ -29,7 +29,7 @@ const CustomerDashboard: React.FC<CustomerDashboardProps> = ({ setCurrentPage, c
     return (
         <div className="space-y-8">
             <section>
-                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200">Welcome back, {currentUser.name.split(' ')[0]}!</h2>
+                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200">Welcome back, {currentUser.username.split(' ')[0]}!</h2>
                 <p className="text-gray-500 dark:text-gray-400">Here's a summary of your account.</p>
             </section>
             

--- a/Frontend-PWD/components/Header.tsx
+++ b/Frontend-PWD/components/Header.tsx
@@ -80,7 +80,7 @@ const Header: React.FC<HeaderProps> = ({ title, setSidebarOpen, currentUser, not
                 src={`https://i.pravatar.cc/100?u=${currentUser?.email}`}
                 alt="User Avatar"
               />
-              <span className="hidden md:inline text-sm font-medium text-gray-700 dark:text-gray-300">{currentUser?.name}</span>
+              <span className="hidden md:inline text-sm font-medium text-gray-700 dark:text-gray-300">{currentUser?.username}</span>
               <svg className="h-5 w-5 text-gray-500 hidden md:inline" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd" /></svg>
             </button>
             {showUserMenu && (

--- a/Frontend-PWD/components/InvestorDashboard.tsx
+++ b/Frontend-PWD/components/InvestorDashboard.tsx
@@ -48,7 +48,7 @@ const InvestorDashboard: React.FC<InvestorDashboardProps> = ({ setCurrentPage, c
     return (
         <div className="space-y-8">
             <section>
-                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200">Welcome, {currentUser.name}!</h2>
+                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200">Welcome, {currentUser.username}!</h2>
                 <p className="text-gray-500 dark:text-gray-400">Here's a summary of your investment portfolio.</p>
             </section>
             

--- a/Frontend-PWD/components/Login.tsx
+++ b/Frontend-PWD/components/Login.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { User, Page } from '../types';
-import { USERS } from '../constants';
+import { login } from '../services/auth';
 
 interface LoginProps {
   onLogin: (user: User) => void;
@@ -13,16 +13,13 @@ const Login: React.FC<LoginProps> = ({ onLogin, setCurrentPage }) => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-
-    // Mock authentication
-    const user = USERS.find(u => u.email === email && u.password === password);
-    
-    if (user) {
+    try {
+      const user = await login(email, password);
       onLogin(user);
-    } else {
+    } catch {
       setError('Invalid email or password.');
     }
   };

--- a/Frontend-PWD/components/MyLeave.tsx
+++ b/Frontend-PWD/components/MyLeave.tsx
@@ -80,7 +80,7 @@ const MyLeave: React.FC<{ currentUser: User }> = ({ currentUser }) => {
             ...requestData,
             id: Math.max(0, ...leaveRequests.map(r => r.id)) + 1,
             employeeId: currentUser.id,
-            employeeName: currentUser.name,
+            employeeName: currentUser.username,
             status: 'PENDING'
         };
         setLeaveRequests(prev => [newRequest, ...prev]);

--- a/Frontend-PWD/components/constants.tsx
+++ b/Frontend-PWD/components/constants.tsx
@@ -32,13 +32,13 @@ export const ICONS = {
 
 
 export const USERS: User[] = [
-    { id: 1, name: 'Admin User', email: 'admin@pharma.com', password: 'password', role: 'SUPER_ADMIN' },
-    { id: 101, name: 'City Pharmacy Rep', email: 'cp@pharma.com', password: 'password', role: 'CUSTOMER' },
-    { id: 102, name: 'Wellness Drug Rep', email: 'wd@pharma.com', password: 'password', role: 'CUSTOMER' },
-    { id: 201, name: 'Walter House', email: 'warehouse@pharma.com', password: 'password', role: 'WAREHOUSE_ADMIN'},
-    { id: 202, name: 'David Manager', email: 'delivery@pharma.com', password: 'password', role: 'DELIVERY_MANAGER'},
-    { id: 203, name: 'Rachel Officer', email: 'recovery@pharma.com', password: 'password', role: 'RECOVERY_OFFICER'},
-    { id: 301, name: 'Ivy Investor', email: 'investor@pharma.com', password: 'password', role: 'INVESTOR'}
+    { id: 1, username: 'Admin User', email: 'admin@pharma.com', password: 'password', role: 'SUPER_ADMIN' },
+    { id: 101, username: 'City Pharmacy Rep', email: 'cp@pharma.com', password: 'password', role: 'CUSTOMER' },
+    { id: 102, username: 'Wellness Drug Rep', email: 'wd@pharma.com', password: 'password', role: 'CUSTOMER' },
+    { id: 201, username: 'Walter House', email: 'warehouse@pharma.com', password: 'password', role: 'WAREHOUSE_ADMIN'},
+    { id: 202, username: 'David Manager', email: 'delivery@pharma.com', password: 'password', role: 'DELIVERY_MANAGER'},
+    { id: 203, username: 'Rachel Officer', email: 'recovery@pharma.com', password: 'password', role: 'RECOVERY_OFFICER'},
+    { id: 301, username: 'Ivy Investor', email: 'investor@pharma.com', password: 'password', role: 'INVESTOR'}
 ];
 
 export const CITIES: City[] = [

--- a/Frontend-PWD/constants.tsx
+++ b/Frontend-PWD/constants.tsx
@@ -32,13 +32,13 @@ export const ICONS = {
 
 
 export const USERS: User[] = [
-    { id: 1, name: 'Admin User', email: 'admin@pharma.com', password: 'password', role: 'SUPER_ADMIN' },
-    { id: 101, name: 'City Pharmacy Rep', email: 'cp@pharma.com', password: 'password', role: 'CUSTOMER' },
-    { id: 102, name: 'Wellness Drug Rep', email: 'wd@pharma.com', password: 'password', role: 'CUSTOMER' },
-    { id: 201, name: 'Walter House', email: 'warehouse@pharma.com', password: 'password', role: 'WAREHOUSE_ADMIN'},
-    { id: 202, name: 'David Manager', email: 'delivery@pharma.com', password: 'password', role: 'DELIVERY_MANAGER'},
-    { id: 203, name: 'Rachel Officer', email: 'recovery@pharma.com', password: 'password', role: 'RECOVERY_OFFICER'},
-    { id: 301, name: 'Ivy Investor', email: 'investor@pharma.com', password: 'password', role: 'INVESTOR'}
+    { id: 1, username: 'Admin User', email: 'admin@pharma.com', password: 'password', role: 'SUPER_ADMIN' },
+    { id: 101, username: 'City Pharmacy Rep', email: 'cp@pharma.com', password: 'password', role: 'CUSTOMER' },
+    { id: 102, username: 'Wellness Drug Rep', email: 'wd@pharma.com', password: 'password', role: 'CUSTOMER' },
+    { id: 201, username: 'Walter House', email: 'warehouse@pharma.com', password: 'password', role: 'WAREHOUSE_ADMIN'},
+    { id: 202, username: 'David Manager', email: 'delivery@pharma.com', password: 'password', role: 'DELIVERY_MANAGER'},
+    { id: 203, username: 'Rachel Officer', email: 'recovery@pharma.com', password: 'password', role: 'RECOVERY_OFFICER'},
+    { id: 301, username: 'Ivy Investor', email: 'investor@pharma.com', password: 'password', role: 'INVESTOR'}
 ];
 
 export const CITIES: City[] = [

--- a/Frontend-PWD/services/auth.ts
+++ b/Frontend-PWD/services/auth.ts
@@ -1,0 +1,32 @@
+import { User } from '../types';
+
+const TOKEN_KEY = 'authToken';
+const USER_KEY = 'currentUser';
+
+export async function login(email: string, password: string): Promise<User> {
+  const response = await fetch('/api/user/auth/login/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: email, password }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Login failed');
+  }
+
+  const data = await response.json();
+  localStorage.setItem(TOKEN_KEY, data.token);
+  localStorage.setItem(USER_KEY, JSON.stringify(data.user));
+  return data.user as User;
+}
+
+export function logout(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+}
+
+export function getCurrentUser(): User | null {
+  const stored = localStorage.getItem(USER_KEY);
+  return stored ? (JSON.parse(stored) as User) : null;
+}
+

--- a/Frontend-PWD/types.ts
+++ b/Frontend-PWD/types.ts
@@ -2,7 +2,7 @@ export type UserRole = 'SUPER_ADMIN' | 'CUSTOMER' | 'MANAGER' | 'SALES' | 'DELIV
 
 export interface User {
     id: number;
-    name: string;
+    username: string;
     email: string;
     password?: string; // Should not be stored in frontend state long-term
     role: UserRole;

--- a/erp/settings.py
+++ b/erp/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
     'hr',
     'setting',
     'inventory',
@@ -61,13 +62,10 @@ INSTALLED_APPS = [
 
 
 
-    'rest_framework',
-
     'crm',
     'task',
     'notification',
     'pricing',
-    'expense',
     'investor',
     'syncqueue',
 

--- a/erp/urls.py
+++ b/erp/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path('api/expenses/', include('expense.urls')),
     path('api/investor/', include('investor.urls')),
     path('api/sync/', include('syncqueue.urls')),
+    path('api/user/', include('user.urls')),
 
 
 

--- a/user/serializers.py
+++ b/user/serializers.py
@@ -1,0 +1,37 @@
+from django.contrib.auth import authenticate
+from rest_framework import serializers
+
+from .models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """Serializer for the User model exposing basic fields."""
+
+    class Meta:
+        model = User
+        fields = ("id", "username", "email", "role")
+
+
+class AuthTokenSerializer(serializers.Serializer):
+    """Serializer for obtaining auth tokens using login credentials."""
+
+    username = serializers.CharField()
+    password = serializers.CharField(trim_whitespace=False, write_only=True)
+
+    def validate(self, attrs):
+        username = attrs.get("username")
+        password = attrs.get("password")
+
+        user = authenticate(
+            request=self.context.get("request"),
+            username=username,
+            password=password,
+        )
+        if not user:
+            raise serializers.ValidationError(
+                "Unable to authenticate with provided credentials",
+                code="authorization",
+            )
+        attrs["user"] = user
+        return attrs
+

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,0 +1,15 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .views import AuthViewSet, UserViewSet
+
+
+router = DefaultRouter()
+router.register(r"users", UserViewSet)
+router.register(r"auth", AuthViewSet, basename="auth")
+
+
+urlpatterns = [
+    path("", include(router.urls)),
+]
+

--- a/user/views.py
+++ b/user/views.py
@@ -1,3 +1,40 @@
-from django.shortcuts import render
+from rest_framework import permissions, viewsets
+from rest_framework.authtoken.models import Token
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
-# Create your views here.
+from .models import User
+from .serializers import AuthTokenSerializer, UserSerializer
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    """ViewSet providing CRUD operations for users and a `me` endpoint."""
+
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    @action(detail=False, methods=["get"], permission_classes=[permissions.IsAuthenticated])
+    def me(self, request):
+        serializer = self.get_serializer(request.user)
+        return Response(serializer.data)
+
+
+class AuthViewSet(viewsets.ViewSet):
+    """ViewSet handling authentication actions like login and token refresh."""
+
+    serializer_class = AuthTokenSerializer
+
+    @action(detail=False, methods=["post"], url_path="login")
+    def login(self, request):
+        serializer = self.serializer_class(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        user = serializer.validated_data["user"]
+        token, _ = Token.objects.get_or_create(user=user)
+        return Response({"token": token.key, "user": UserSerializer(user).data})
+
+    @action(detail=False, methods=["post"], url_path="refresh", permission_classes=[permissions.IsAuthenticated])
+    def refresh(self, request):
+        token, _ = Token.objects.get_or_create(user=request.user)
+        return Response({"token": token.key})
+


### PR DESCRIPTION
## Summary
- add DRF serializers and viewsets for user CRUD, login and token refresh
- expose authentication API routes and include them in project settings
- create frontend auth service and update components to use username-based user model

## Testing
- `python manage.py test` *(fails: SyntaxError in sale/migrations/0001_initial.py)*
- `npm --prefix Frontend-PWD install --legacy-peer-deps`
- `npm --prefix Frontend-PWD run build`


------
https://chatgpt.com/codex/tasks/task_e_688fcbe8377483298f504e0420cda4ef