### PR TITLE
Add HR module APIs and frontend integration

### DIFF
--- a/Frontend-PWD/components/MyLeave.tsx
+++ b/Frontend-PWD/components/MyLeave.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { User, LeaveRequest, LeaveType, LeaveStatus } from '../types';
-import { LEAVE_REQUESTS } from '../constants';
 import { ICONS } from '../constants';
-import { addToSyncQueue, registerSync } from '../services/db';
+import { getLeaveRequests, createLeaveRequest } from '../services/hr';
 
-const LeaveFormModal: React.FC<{ onClose: () => void; onSave: (request: Omit<LeaveRequest, 'id' | 'employeeId' | 'employeeName' | 'status'>) => void; }> = ({ onClose, onSave }) => {
+const LeaveFormModal: React.FC<{ onClose: () => void; onSave: (request: Omit<LeaveRequest, 'id' | 'employee' | 'status' | 'appliedOn' | 'reviewedBy'>) => void; }> = ({ onClose, onSave }) => {
     const [formData, setFormData] = useState({ leaveType: 'ANNUAL' as LeaveType, startDate: '', endDate: '', reason: '' });
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => { setFormData({ ...formData, [e.target.name]: e.target.value }); };
     const handleSubmit = (e: React.FormEvent) => {
@@ -59,31 +58,25 @@ const StatusBadge: React.FC<{ status: LeaveStatus }> = ({ status }) => {
 
 
 const MyLeave: React.FC<{ currentUser: User }> = ({ currentUser }) => {
-    const [leaveRequests, setLeaveRequests] = useState<LeaveRequest[]>(LEAVE_REQUESTS);
+    const [leaveRequests, setLeaveRequests] = useState<LeaveRequest[]>([]);
     const [isModalOpen, setIsModalOpen] = useState(false);
 
+    useEffect(() => {
+        getLeaveRequests(currentUser.id).then(setLeaveRequests);
+    }, [currentUser.id]);
+
     const myRequests = useMemo(() => {
-        return leaveRequests.filter(req => req.employeeId === currentUser.id)
+        return leaveRequests
+            .filter(req => req.employee === currentUser.id)
             .sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime());
     }, [leaveRequests, currentUser.id]);
 
-    const handleSaveRequest = async (requestData: Omit<LeaveRequest, 'id' | 'employeeName' | 'status' | 'employeeId'>) => {
-        const payload = {
-            ...requestData,
-            employeeId: currentUser.id,
-        };
-        await addToSyncQueue({ endpoint: '/api/leave-requests', method: 'POST', payload });
-        await registerSync();
-        
-        // Optimistic UI update
-        const newRequest: LeaveRequest = {
-            ...requestData,
-            id: Math.max(0, ...leaveRequests.map(r => r.id)) + 1,
-            employeeId: currentUser.id,
-            employeeName: currentUser.name,
-            status: 'PENDING'
-        };
-        setLeaveRequests(prev => [newRequest, ...prev]);
+    const handleSaveRequest = async (
+        requestData: Omit<LeaveRequest, 'id' | 'employee' | 'status' | 'appliedOn' | 'reviewedBy'>
+    ) => {
+        const payload = { ...requestData, employee: currentUser.id };
+        const saved = await createLeaveRequest(payload);
+        setLeaveRequests(prev => [saved, ...prev]);
         setIsModalOpen(false);
     };
 

--- a/Frontend-PWD/components/Tasks.tsx
+++ b/Frontend-PWD/components/Tasks.tsx
@@ -1,98 +1,107 @@
-
-import React, { useState, useMemo } from 'react';
-import { Task, TaskStatus, User } from '../types';
-import { TASKS, EMPLOYEES, PARTIES_DATA, LEADS, ORDERS, PURCHASE_INVOICES } from '../constants';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Employee, Task, TaskStatus, User } from '../types';
 import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
 import SearchableSelect from './SearchableSelect';
-import { addToSyncQueue, registerSync } from '../services/db';
+import {
+    getTasks,
+    createTask,
+    updateTask,
+    getEmployees,
+} from '../services/hr';
 
-const TaskFormModal: React.FC<{ task: Partial<Task> | null; onClose: () => void; onSave: (task: any) => void; }> = ({ task, onClose, onSave }) => {
-    const [formData, setFormData] = useState<Partial<Task>>(task || { status: 'Pending' });
-    const [relatedToType, setRelatedToType] = useState(task?.relatedTo?.type || null);
-    
-    const handleChange = (name: string, value: any) => { setFormData(prev => ({...prev, [name]: value})); };
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => { handleChange(e.target.name, e.target.value); };
-    
-    const handleSubmit = (e: React.FormEvent) => { 
-        e.preventDefault(); 
-        const finalData = {
-            ...formData,
-            relatedTo: {
-                type: relatedToType,
-                id: formData.relatedTo?.id,
-                name: getRelatedToName(relatedToType, formData.relatedTo?.id)
-            }
-        };
+const TaskFormModal: React.FC<{
+    task: Partial<Task> | null;
+    employees: Employee[];
+    onClose: () => void;
+    onSave: (task: Partial<Task>) => void;
+}> = ({ task, employees, onClose, onSave }) => {
+    const [formData, setFormData] = useState<Partial<Task>>(task || { status: 'PENDING' });
 
-        if (relatedToType && !finalData.relatedTo.id) {
-            alert('Please select an item to relate this task to.');
-            return;
-        }
-        if (!relatedToType) {
-            delete (finalData as Partial<Task>).relatedTo;
-        }
-
-        onSave(finalData); 
+    const handleChange = (name: string, value: any) => {
+        setFormData(prev => ({ ...prev, [name]: value }));
     };
 
-    const relatedToTypeOptions = [
-        { value: 'SaleInvoice', label: 'Sale Invoice' },
-        { value: 'PurchaseInvoice', label: 'Purchase Invoice' },
-        { value: 'Customer', label: 'Customer' },
-        { value: 'Lead', label: 'Lead' },
-    ];
+    const handleInputChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+    ) => {
+        handleChange(e.target.name, e.target.value);
+    };
 
-    const relatedToItemOptions = useMemo(() => {
-        switch(relatedToType) {
-            case 'SaleInvoice': return ORDERS.map(o => ({ value: o.id, label: `${o.invoiceNo} - ${o.customer?.name}` }));
-            case 'PurchaseInvoice': return PURCHASE_INVOICES.map(pi => ({ value: pi.id, label: `${pi.invoiceNo} - ${pi.supplier?.name}` }));
-            case 'Customer': return PARTIES_DATA.filter(p => p.partyType === 'customer').map(c => ({ value: c.id, label: c.name }));
-            case 'Lead': return LEADS.map(l => ({ value: l.id, label: l.name }));
-            default: return [];
-        }
-    }, [relatedToType]);
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        onSave(formData);
+    };
 
-    const getRelatedToName = (type: any, id: any) => {
-        if (!type || !id) return '';
-        switch(type) {
-            case 'SaleInvoice': return ORDERS.find(o => o.id === id)?.invoiceNo;
-            case 'PurchaseInvoice': return PURCHASE_INVOICES.find(pi => pi.id === id)?.invoiceNo;
-            case 'Customer': return PARTIES_DATA.find(p => p.id === id)?.name;
-            case 'Lead': return LEADS.find(l => l.id === id)?.name;
-            default: return '';
-        }
-    }
-
-    const employeeOptions = EMPLOYEES.map(e => ({ value: e.id, label: e.name }));
-    const statusOptions = (['Pending', 'In Progress', 'Completed'] as TaskStatus[]).map(s => ({ value: s, label: s }));
+    const employeeOptions = employees.map(e => ({ value: e.id, label: e.name }));
+    const statusOptions = (
+        ['PENDING', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED'] as TaskStatus[]
+    ).map(s => ({ value: s, label: s.replace('_', ' ') }));
 
     return (
         <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center p-4">
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-lg">
                 <form onSubmit={handleSubmit}>
-                    <div className="p-6 border-b dark:border-gray-700"><h3 className="text-xl font-semibold">{task?.id ? 'Edit' : 'Add'} Task</h3></div>
+                    <div className="p-6 border-b dark:border-gray-700">
+                        <h3 className="text-xl font-semibold">
+                            {task?.id ? 'Edit' : 'Add'} Task
+                        </h3>
+                    </div>
                     <fieldset className="p-6 space-y-4">
-                        <div><label>Title</label><input name="title" value={formData.title || ''} onChange={handleInputChange} required className="mt-1 block w-full text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" /></div>
-                        <div><label>Description</label><textarea name="description" value={formData.description || ''} onChange={handleInputChange} rows={3} className="mt-1 block w-full text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" /></div>
-                        <div className="grid grid-cols-2 gap-4">
-                            <div><label>Assigned To</label><SearchableSelect options={employeeOptions} value={formData.assignedTo || null} onChange={val => handleChange('assignedTo', val)} /></div>
-                            <div><label>Due Date</label><input type="date" name="dueDate" value={formData.dueDate || ''} onChange={handleInputChange} required className="mt-1 block w-full text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700" /></div>
+                        <div>
+                            <label>Assignment</label>
+                            <input
+                                name="assignment"
+                                value={formData.assignment || ''}
+                                onChange={handleInputChange}
+                                required
+                                className="mt-1 block w-full text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                            />
                         </div>
                         <div className="grid grid-cols-2 gap-4">
-                           <div><label>Status</label><SearchableSelect options={statusOptions} value={formData.status} onChange={val => handleChange('status', val)} /></div>
-                        </div>
-                         <fieldset className="p-3 border dark:border-gray-700 rounded-md">
-                            <legend className="px-1 text-sm">Related To (Optional)</legend>
-                            <div className="grid grid-cols-2 gap-4">
-                                <div><label>Type</label><SearchableSelect options={relatedToTypeOptions} value={relatedToType} onChange={val => { setRelatedToType(val as any); handleChange('relatedTo', { id: null, type: val }); }} /></div>
-                                <div><label>Item</label><SearchableSelect options={relatedToItemOptions} value={formData.relatedTo?.id || null} onChange={val => handleChange('relatedTo', { ...(formData.relatedTo as object), id: val })} disabled={!relatedToType} /></div>
+                            <div>
+                                <label>Assigned To</label>
+                                <SearchableSelect
+                                    options={employeeOptions}
+                                    value={formData.assignedTo || null}
+                                    onChange={val => handleChange('assignedTo', val)}
+                                />
                             </div>
-                        </fieldset>
+                            <div>
+                                <label>Due Date</label>
+                                <input
+                                    type="date"
+                                    name="dueDate"
+                                    value={formData.dueDate || ''}
+                                    onChange={handleInputChange}
+                                    required
+                                    className="mt-1 block w-full text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                                />
+                            </div>
+                        </div>
+                        <div>
+                            <label>Status</label>
+                            <SearchableSelect
+                                options={statusOptions}
+                                value={formData.status || 'PENDING'}
+                                onChange={val => handleChange('status', val)}
+                            />
+                        </div>
                     </fieldset>
-                     <div className="p-4 bg-gray-50 dark:bg-gray-900 flex justify-end space-x-2">
-                        <button type="button" onClick={onClose} className="px-4 py-2 border rounded-md text-sm">Cancel</button>
-                        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm">Save & Sync</button>
+                    <div className="p-4 bg-gray-50 dark:bg-gray-900 flex justify-end space-x-2">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="px-4 py-2 border rounded-md text-sm"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm"
+                        >
+                            Save
+                        </button>
                     </div>
                 </form>
             </div>
@@ -102,38 +111,44 @@ const TaskFormModal: React.FC<{ task: Partial<Task> | null; onClose: () => void;
 
 const StatusBadge: React.FC<{ status: TaskStatus }> = ({ status }) => {
     const colorClasses = {
-        'Pending': 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
-        'In Progress': 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
-        'Completed': 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+        PENDING: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
+        IN_PROGRESS: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
+        COMPLETED: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+        CANCELLED: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300',
     }[status];
-    
-    return <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${colorClasses}`}>{status}</span>;
+
+    return (
+        <span
+            className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${colorClasses}`}
+        >
+            {status.replace('_', ' ')}
+        </span>
+    );
 };
 
-
 const Tasks: React.FC<{ currentUser: User }> = ({ currentUser }) => {
-    const [tasks, setTasks] = useState<Task[]>(TASKS);
+    const [tasks, setTasks] = useState<Task[]>([]);
+    const [employees, setEmployees] = useState<Employee[]>([]);
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingTask, setEditingTask] = useState<Partial<Task> | null>(null);
     const [searchTerm, setSearchTerm] = useState('');
     const [statusFilter, setStatusFilter] = useState<TaskStatus | 'All'>('All');
-    
+
     const isSuperAdmin = currentUser.role === 'SUPER_ADMIN';
 
-    const handleSaveTask = async (taskData: any) => {
-        const method = taskData.id ? 'PUT' : 'POST';
-        const endpoint = taskData.id ? `/api/tasks/${taskData.id}` : '/api/tasks';
-        await addToSyncQueue({ endpoint, method, payload: taskData });
-        await registerSync();
-        
-        // Optimistic UI update
-        setTasks(prev => {
-            if (taskData.id) {
-                return prev.map(t => t.id === taskData.id ? taskData : t);
-            }
-            return [...prev, { ...taskData, id: Date.now(), createdAt: new Date().toISOString() }];
-        });
-        
+    useEffect(() => {
+        getTasks().then(setTasks);
+        getEmployees().then(setEmployees);
+    }, []);
+
+    const handleSaveTask = async (taskData: Partial<Task>) => {
+        const isEdit = !!taskData.id;
+        const saved = isEdit && taskData.id
+            ? await updateTask(taskData.id, taskData)
+            : await createTask(taskData);
+        setTasks(prev =>
+            isEdit ? prev.map(t => (t.id === saved.id ? saved : t)) : [...prev, saved]
+        );
         setIsModalOpen(false);
         setEditingTask(null);
     };
@@ -146,7 +161,9 @@ const Tasks: React.FC<{ currentUser: User }> = ({ currentUser }) => {
     const filteredTasks = useMemo(() => {
         return tasks.filter(task => {
             const matchesUser = isSuperAdmin || task.assignedTo === currentUser.id;
-            const matchesSearch = searchTerm === '' || task.title.toLowerCase().includes(searchTerm.toLowerCase());
+            const matchesSearch =
+                searchTerm === '' ||
+                task.assignment.toLowerCase().includes(searchTerm.toLowerCase());
             const matchesStatus = statusFilter === 'All' || task.status === statusFilter;
             return matchesUser && matchesSearch && matchesStatus;
         });
@@ -156,45 +173,97 @@ const Tasks: React.FC<{ currentUser: User }> = ({ currentUser }) => {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
             <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
                 <h3 className="text-lg font-semibold">Task Management</h3>
-                <button onClick={() => openModal()} className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md">New Task</button>
+                <button
+                    onClick={() => openModal()}
+                    className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md"
+                >
+                    New Task
+                </button>
             </div>
             <FilterBar>
-                <SearchInput placeholder="Search tasks..." value={searchTerm} onChange={e => setSearchTerm(e.target.value)} />
-                <FilterControls.Select value={statusFilter} onChange={e => setStatusFilter(e.target.value as any)}>
+                <SearchInput
+                    placeholder="Search tasks..."
+                    value={searchTerm}
+                    onChange={e => setSearchTerm(e.target.value)}
+                />
+                <FilterControls.Select
+                    value={statusFilter}
+                    onChange={e => setStatusFilter(e.target.value as any)}
+                >
                     <option value="All">All Statuses</option>
-                    <option value="Pending">Pending</option>
-                    <option value="In Progress">In Progress</option>
-                    <option value="Completed">Completed</option>
+                    <option value="PENDING">PENDING</option>
+                    <option value="IN_PROGRESS">IN_PROGRESS</option>
+                    <option value="COMPLETED">COMPLETED</option>
+                    <option value="CANCELLED">CANCELLED</option>
                 </FilterControls.Select>
-                <FilterControls.ResetButton onClick={() => { setSearchTerm(''); setStatusFilter('All'); }} />
+                <FilterControls.ResetButton
+                    onClick={() => {
+                        setSearchTerm('');
+                        setStatusFilter('All');
+                    }}
+                />
             </FilterBar>
             <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                     <thead className="bg-gray-50 dark:bg-gray-700">
                         <tr>
-                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
-                            {isSuperAdmin && <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Assigned To</th>}
-                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Due Date</th>
-                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                            <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                                Assignment
+                            </th>
+                            {isSuperAdmin && (
+                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                                    Assigned To
+                                </th>
+                            )}
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                                Due Date
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                                Status
+                            </th>
+                            <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">
+                                Actions
+                            </th>
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-gray-600">
                         {filteredTasks.map(task => (
                             <tr key={task.id}>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{task.title}</td>
-                                {isSuperAdmin && <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{EMPLOYEES.find(e => e.id === task.assignedTo)?.name || 'N/A'}</td>}
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{task.dueDate}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm"><StatusBadge status={task.status} /></td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                                    {task.assignment}
+                                </td>
+                                {isSuperAdmin && (
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                        {employees.find(e => e.id === task.assignedTo)?.name || 'N/A'}
+                                    </td>
+                                )}
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                    {task.dueDate}
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                                    <StatusBadge status={task.status} />
+                                </td>
                                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                    <button onClick={() => openModal(task)} className="text-blue-600 hover:text-blue-900">Edit</button>
+                                    <button
+                                        onClick={() => openModal(task)}
+                                        className="text-blue-600 hover:text-blue-900"
+                                    >
+                                        Edit
+                                    </button>
                                 </td>
                             </tr>
                         ))}
                     </tbody>
                 </table>
             </div>
-            {isModalOpen && <TaskFormModal task={editingTask} onClose={() => setIsModalOpen(false)} onSave={handleSaveTask} />}
+            {isModalOpen && (
+                <TaskFormModal
+                    task={editingTask}
+                    employees={employees}
+                    onClose={() => setIsModalOpen(false)}
+                    onSave={handleSaveTask}
+                />
+            )}
         </div>
     );
 };

--- a/Frontend-PWD/constants.tsx
+++ b/Frontend-PWD/constants.tsx
@@ -129,36 +129,36 @@ export const EMPLOYEES: Employee[] = [
 ];
 
 export const EMPLOYEE_CONTRACTS: EmployeeContract[] = [
-    { id: 1, employeeId: 1, startDate: '2022-01-01', endDate: null, salary: 75000, notes: 'Managerial role' },
-    { id: 2, employeeId: 2, startDate: '2023-03-15', endDate: null, salary: 55000, notes: 'Sales commission applies' },
-    { id: 3, employeeId: 3, startDate: '2023-05-20', endDate: '2024-05-19', salary: 42000, notes: '1-year contract' }
+    { id: 1, employee: 1, startDate: '2022-01-01', endDate: null, salary: 75000, notes: 'Managerial role' },
+    { id: 2, employee: 2, startDate: '2023-03-15', endDate: null, salary: 55000, notes: 'Sales commission applies' },
+    { id: 3, employee: 3, startDate: '2023-05-20', endDate: '2024-05-19', salary: 42000, notes: '1-year contract' }
 ];
 
 export const SALES_TARGETS: SalesTarget[] = [
-    { id: 1, employeeId: 2, month: '2024-07-01', targetAmount: 50000 },
-    { id: 2, employeeId: 2, month: '2024-08-01', targetAmount: 52000 }
+    { id: 1, employee: 2, month: '2024-07-01', targetAmount: 50000 },
+    { id: 2, employee: 2, month: '2024-08-01', targetAmount: 52000 }
 ];
 
 
 export const LEAVE_REQUESTS: LeaveRequest[] = [
-    { id: 1, employeeId: 2, employeeName: 'Jane Smith', leaveType: 'ANNUAL', startDate: '2024-08-10', endDate: '2024-08-15', status: 'PENDING', reason: 'Family vacation' },
-    { id: 2, employeeId: 3, employeeName: 'Peter Jones', leaveType: 'SICK', startDate: '2024-07-22', endDate: '2024-07-23', status: 'APPROVED' },
-    { id: 3, employeeId: 4, employeeName: 'Mary Johnson', leaveType: 'CASUAL', startDate: '2024-07-25', endDate: '2024-07-25', status: 'REJECTED', reason: 'Insufficient staff coverage' },
-    { id: 4, employeeId: 2, employeeName: 'Jane Smith', leaveType: 'SICK', startDate: '2024-06-05', endDate: '2024-06-05', status: 'APPROVED' },
-    { id: 5, employeeId: 201, employeeName: 'Walter House', leaveType: 'ANNUAL', startDate: '2024-09-01', endDate: '2024-09-05', status: 'PENDING', reason: 'Personal time off' },
-    { id: 6, employeeId: 202, employeeName: 'David Manager', leaveType: 'SICK', startDate: '2024-08-05', endDate: '2024-08-05', status: 'APPROVED' }
+    { id: 1, employee: 2, leaveType: 'ANNUAL', startDate: '2024-08-10', endDate: '2024-08-15', status: 'PENDING', reason: 'Family vacation', appliedOn: '2024-07-01T00:00:00Z', reviewedBy: null },
+    { id: 2, employee: 3, leaveType: 'SICK', startDate: '2024-07-22', endDate: '2024-07-23', status: 'APPROVED', appliedOn: '2024-07-01T00:00:00Z', reviewedBy: null },
+    { id: 3, employee: 4, leaveType: 'CASUAL', startDate: '2024-07-25', endDate: '2024-07-25', status: 'REJECTED', reason: 'Insufficient staff coverage', appliedOn: '2024-07-01T00:00:00Z', reviewedBy: null },
+    { id: 4, employee: 2, leaveType: 'SICK', startDate: '2024-06-05', endDate: '2024-06-05', status: 'APPROVED', appliedOn: '2024-06-01T00:00:00Z', reviewedBy: null },
+    { id: 5, employee: 201, leaveType: 'ANNUAL', startDate: '2024-09-01', endDate: '2024-09-05', status: 'PENDING', reason: 'Personal time off', appliedOn: '2024-08-01T00:00:00Z', reviewedBy: null },
+    { id: 6, employee: 202, leaveType: 'SICK', startDate: '2024-08-05', endDate: '2024-08-05', status: 'APPROVED', appliedOn: '2024-07-30T00:00:00Z', reviewedBy: null }
 ];
 
 export const ATTENDANCE_RECORDS: AttendanceRecord[] = [
-    { id: '1-2024-07-28', employeeId: 1, employeeName: 'John Doe', date: '2024-07-28', checkIn: '09:05', checkOut: '17:30', isAbsent: false },
-    { id: '2-2024-07-28', employeeId: 2, employeeName: 'Jane Smith', date: '2024-07-28', checkIn: '09:00', checkOut: '17:25', isAbsent: false },
-    { id: '3-2024-07-28', employeeId: 3, employeeName: 'Peter Jones', date: '2024-07-28', checkIn: null, checkOut: null, isAbsent: true },
-    { id: '201-2024-07-28', employeeId: 201, employeeName: 'Walter House', date: '2024-07-28', checkIn: '08:55', checkOut: '17:00', isAbsent: false },
-    
-    { id: '1-2024-07-29', employeeId: 1, employeeName: 'John Doe', date: '2024-07-29', checkIn: '09:10', checkOut: '17:45', isAbsent: false },
-    { id: '2-2024-07-29', employeeId: 2, employeeName: 'Jane Smith', date: '2024-07-29', checkIn: '09:02', checkOut: '17:30', isAbsent: false },
-    { id: '3-2024-07-29', employeeId: 3, employeeName: 'Peter Jones', date: '2024-07-29', checkIn: '08:45', checkOut: '17:15', isAbsent: false },
-    { id: '201-2024-07-29', employeeId: 201, employeeName: 'Walter House', date: '2024-07-29', checkIn: '08:58', checkOut: '17:05', isAbsent: false },
+    { id: 1, employee: 1, date: '2024-07-28', checkIn: '09:05', checkOut: '17:30', isAbsent: false, remarks: '' },
+    { id: 2, employee: 2, date: '2024-07-28', checkIn: '09:00', checkOut: '17:25', isAbsent: false, remarks: '' },
+    { id: 3, employee: 3, date: '2024-07-28', checkIn: null, checkOut: null, isAbsent: true, remarks: '' },
+    { id: 4, employee: 201, date: '2024-07-28', checkIn: '08:55', checkOut: '17:00', isAbsent: false, remarks: '' },
+
+    { id: 5, employee: 1, date: '2024-07-29', checkIn: '09:10', checkOut: '17:45', isAbsent: false, remarks: '' },
+    { id: 6, employee: 2, date: '2024-07-29', checkIn: '09:02', checkOut: '17:30', isAbsent: false, remarks: '' },
+    { id: 7, employee: 3, date: '2024-07-29', checkIn: '08:45', checkOut: '17:15', isAbsent: false, remarks: '' },
+    { id: 8, employee: 201, date: '2024-07-29', checkIn: '08:58', checkOut: '17:05', isAbsent: false, remarks: '' },
 ];
 
 
@@ -290,10 +290,10 @@ export const INTERACTIONS: Interaction[] = [
 
 // Task Management Mock Data
 export const TASKS: Task[] = [
-    { id: 1, title: 'Follow-up on INV-2024-003', description: 'Call City Pharmacy to confirm payment for invoice INV-2024-003.', assignedTo: 2, dueDate: '2024-08-10', status: 'Pending', relatedTo: { type: 'SaleInvoice', id: '3', name: 'INV-2024-003' }, createdAt: '2024-07-26T10:00:00Z' },
-    { id: 2, title: 'Prepare stock for PI-2024-055', description: 'Unpack and verify stock received from PharmaCo Global.', assignedTo: 201, dueDate: '2024-07-26', status: 'Completed', relatedTo: { type: 'PurchaseInvoice', id: 'pi-1', name: 'PI-2024-055' }, createdAt: '2024-07-25T11:00:00Z' },
-    { id: 3, title: 'Qualify lead: General Hospital', assignedTo: 2, dueDate: '2024-07-30', status: 'In Progress', relatedTo: { type: 'Lead', id: 1, name: 'General Hospital' }, createdAt: '2024-07-22T10:05:00Z' },
-    { id: 4, title: 'Check credit limit for Wellness Drug Store', description: 'Review current balance and discuss potential credit limit increase.', assignedTo: 1, dueDate: '2024-08-05', status: 'Pending', relatedTo: { type: 'Customer', id: 102, name: 'Wellness Drug Store' }, createdAt: '2024-07-29T09:00:00Z' }
+    { id: 1, assignment: 'Follow-up on INV-2024-003', assignedTo: 2, assignedBy: null, dueDate: '2024-08-10', status: 'PENDING', createdAt: '2024-07-26T10:00:00Z', updatedAt: '2024-07-26T10:00:00Z', party: null, invoiceContentType: null, invoiceObjectId: null },
+    { id: 2, assignment: 'Prepare stock for PI-2024-055', assignedTo: 201, assignedBy: null, dueDate: '2024-07-26', status: 'COMPLETED', createdAt: '2024-07-25T11:00:00Z', updatedAt: '2024-07-25T11:00:00Z', party: null, invoiceContentType: null, invoiceObjectId: null },
+    { id: 3, assignment: 'Qualify lead: General Hospital', assignedTo: 2, assignedBy: null, dueDate: '2024-07-30', status: 'IN_PROGRESS', createdAt: '2024-07-22T10:05:00Z', updatedAt: '2024-07-22T10:05:00Z', party: null, invoiceContentType: null, invoiceObjectId: null },
+    { id: 4, assignment: 'Check credit limit for Wellness Drug Store', assignedTo: 1, assignedBy: null, dueDate: '2024-08-05', status: 'PENDING', createdAt: '2024-07-29T09:00:00Z', updatedAt: '2024-07-29T09:00:00Z', party: null, invoiceContentType: null, invoiceObjectId: null }
 ];
 
 // Investor Mock Data

--- a/Frontend-PWD/services/hr.ts
+++ b/Frontend-PWD/services/hr.ts
@@ -1,0 +1,97 @@
+import { AttendanceRecord, Employee, EmployeeContract, LeaveBalance, LeaveRequest, PayrollSlip, SalesTarget, Task } from '../types';
+
+const API_BASE = '/api/hr';
+
+async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+    const res = await fetch(url, {
+        headers: { 'Content-Type': 'application/json' },
+        ...options,
+    });
+    if (!res.ok) {
+        throw new Error(await res.text());
+    }
+    if (res.status === 204) {
+        return {} as T;
+    }
+    return res.json();
+}
+
+// Employees
+export const getEmployees = () => request<Employee[]>(`${API_BASE}/employees/`);
+export const createEmployee = (data: Partial<Employee>) =>
+    request<Employee>(`${API_BASE}/employees/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateEmployee = (id: number, data: Partial<Employee>) =>
+    request<Employee>(`${API_BASE}/employees/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteEmployee = (id: number) =>
+    request<void>(`${API_BASE}/employees/${id}/`, { method: 'DELETE' });
+
+// Employee Contracts
+export const getEmployeeContracts = () => request<EmployeeContract[]>(`${API_BASE}/contracts/`);
+export const createEmployeeContract = (data: Partial<EmployeeContract>) =>
+    request<EmployeeContract>(`${API_BASE}/contracts/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateEmployeeContract = (id: number, data: Partial<EmployeeContract>) =>
+    request<EmployeeContract>(`${API_BASE}/contracts/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteEmployeeContract = (id: number) =>
+    request<void>(`${API_BASE}/contracts/${id}/`, { method: 'DELETE' });
+
+// Leave Requests
+export const getLeaveRequests = (employee?: number) => {
+    const url = employee ? `${API_BASE}/leave-requests/?employee=${employee}` : `${API_BASE}/leave-requests/`;
+    return request<LeaveRequest[]>(url);
+};
+export const createLeaveRequest = (data: Partial<LeaveRequest>) =>
+    request<LeaveRequest>(`${API_BASE}/leave-requests/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateLeaveRequest = (id: number, data: Partial<LeaveRequest>) =>
+    request<LeaveRequest>(`${API_BASE}/leave-requests/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteLeaveRequest = (id: number) =>
+    request<void>(`${API_BASE}/leave-requests/${id}/`, { method: 'DELETE' });
+
+// Attendance
+export const getAttendance = () => request<AttendanceRecord[]>(`${API_BASE}/attendance/`);
+export const createAttendance = (data: Partial<AttendanceRecord>) =>
+    request<AttendanceRecord>(`${API_BASE}/attendance/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateAttendance = (id: number, data: Partial<AttendanceRecord>) =>
+    request<AttendanceRecord>(`${API_BASE}/attendance/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteAttendance = (id: number) =>
+    request<void>(`${API_BASE}/attendance/${id}/`, { method: 'DELETE' });
+
+// Sales Targets
+export const getSalesTargets = () => request<SalesTarget[]>(`${API_BASE}/sales-targets/`);
+export const createSalesTarget = (data: Partial<SalesTarget>) =>
+    request<SalesTarget>(`${API_BASE}/sales-targets/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateSalesTarget = (id: number, data: Partial<SalesTarget>) =>
+    request<SalesTarget>(`${API_BASE}/sales-targets/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteSalesTarget = (id: number) =>
+    request<void>(`${API_BASE}/sales-targets/${id}/`, { method: 'DELETE' });
+
+// Tasks
+export const getTasks = () => request<Task[]>(`${API_BASE}/tasks/`);
+export const createTask = (data: Partial<Task>) =>
+    request<Task>(`${API_BASE}/tasks/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateTask = (id: number, data: Partial<Task>) =>
+    request<Task>(`${API_BASE}/tasks/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteTask = (id: number) =>
+    request<void>(`${API_BASE}/tasks/${id}/`, { method: 'DELETE' });
+
+// Delivery Assignments
+export const getDeliveryAssignments = () => request<any[]>(`${API_BASE}/delivery-assignments/`);
+export const createDeliveryAssignment = (data: any) =>
+    request<any>(`${API_BASE}/delivery-assignments/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateDeliveryAssignment = (id: number, data: any) =>
+    request<any>(`${API_BASE}/delivery-assignments/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteDeliveryAssignment = (id: number) =>
+    request<void>(`${API_BASE}/delivery-assignments/${id}/`, { method: 'DELETE' });
+
+// Leave Balances
+export const getLeaveBalances = () => request<LeaveBalance[]>(`${API_BASE}/leave-balances/`);
+export const updateLeaveBalance = (id: number, data: Partial<LeaveBalance>) =>
+    request<LeaveBalance>(`${API_BASE}/leave-balances/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+
+// Payroll Slips
+export const getPayrollSlips = () => request<PayrollSlip[]>(`${API_BASE}/payroll-slips/`);
+export const createPayrollSlip = (data: Partial<PayrollSlip>) =>
+    request<PayrollSlip>(`${API_BASE}/payroll-slips/`, { method: 'POST', body: JSON.stringify(data) });
+export const updatePayrollSlip = (id: number, data: Partial<PayrollSlip>) =>
+    request<PayrollSlip>(`${API_BASE}/payroll-slips/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deletePayrollSlip = (id: number) =>
+    request<void>(`${API_BASE}/payroll-slips/${id}/`, { method: 'DELETE' });

--- a/Frontend-PWD/types.ts
+++ b/Frontend-PWD/types.ts
@@ -204,37 +204,41 @@ export type LeaveStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 
 export interface Employee {
     id: number;
-    name: string;
+    user?: number | null;
     role: EmployeeRole;
+    name: string;
     phone: string;
     email?: string;
+    cnic?: string;
+    address?: string;
     active: boolean;
 }
 
 export interface LeaveRequest {
     id: number;
-    employeeId: number;
-    employeeName: string; // Denormalized for easy display
+    employee: number;
     leaveType: LeaveType;
     startDate: string; // YYYY-MM-DD
     endDate: string; // YYYY-MM-DD
     reason?: string;
     status: LeaveStatus;
+    appliedOn: string;
+    reviewedBy?: number | null;
 }
 
 export interface AttendanceRecord {
-    id: string; // e.g., `${employeeId}-${date}`
-    employeeId: number;
-    employeeName: string;
+    id: number;
+    employee: number;
     date: string; // YYYY-MM-DD
     checkIn: string | null; // HH:MM
     checkOut: string | null; // HH:MM
     isAbsent: boolean;
+    remarks?: string;
 }
 
 export interface EmployeeContract {
     id: number;
-    employeeId: number;
+    employee: number;
     startDate: string; // YYYY-MM-DD
     endDate: string | null; // YYYY-MM-DD
     salary: number;
@@ -243,9 +247,46 @@ export interface EmployeeContract {
 
 export interface SalesTarget {
     id: number;
-    employeeId: number;
+    employee: number;
     month: string; // YYYY-MM-01
     targetAmount: number;
+}
+
+export interface LeaveBalance {
+    id: number;
+    employee: number;
+    annual: number;
+    sick: number;
+    casual: number;
+}
+
+export interface PayrollSlip {
+    id: number;
+    employee: number;
+    month: string; // YYYY-MM-01
+    baseSalary: number;
+    presentDays: number;
+    absentDays: number;
+    leavesPaid: number;
+    deductions: number;
+    netSalary: number;
+    createdOn: string;
+}
+
+export type TaskStatus = 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+
+export interface Task {
+    id: number;
+    assignment: string;
+    assignedTo: number;
+    assignedBy?: number | null;
+    dueDate: string; // YYYY-MM-DD
+    status: TaskStatus;
+    party?: number | null;
+    invoiceContentType?: number | null;
+    invoiceObjectId?: number | null;
+    createdAt: string;
+    updatedAt: string;
 }
 
 // Inventory Module Types

--- a/erp/urls.py
+++ b/erp/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path('api/expenses/', include('expense.urls')),
     path('api/investor/', include('investor.urls')),
     path('api/sync/', include('syncqueue.urls')),
+    path('api/hr/', include('hr.urls')),
 
 
 

--- a/hr/serializers.py
+++ b/hr/serializers.py
@@ -1,0 +1,131 @@
+from rest_framework import serializers
+from .models import (
+    Employee,
+    EmployeeContract,
+    LeaveRequest,
+    Attendance,
+    SalesTarget,
+    Task,
+    DeliveryAssignment,
+    LeaveBalance,
+    PayrollSlip,
+)
+
+
+class EmployeeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Employee
+        fields = [
+            "id",
+            "user",
+            "role",
+            "name",
+            "phone",
+            "email",
+            "cnic",
+            "address",
+            "active",
+        ]
+
+
+class EmployeeContractSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EmployeeContract
+        fields = [
+            "id",
+            "employee",
+            "start_date",
+            "end_date",
+            "salary",
+            "notes",
+        ]
+
+
+class LeaveRequestSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LeaveRequest
+        fields = [
+            "id",
+            "employee",
+            "leave_type",
+            "start_date",
+            "end_date",
+            "reason",
+            "status",
+            "applied_on",
+            "reviewed_by",
+        ]
+
+
+class AttendanceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Attendance
+        fields = [
+            "id",
+            "employee",
+            "date",
+            "check_in",
+            "check_out",
+            "is_absent",
+            "remarks",
+        ]
+
+
+class SalesTargetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SalesTarget
+        fields = ["id", "employee", "month", "target_amount"]
+
+
+class TaskSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Task
+        fields = [
+            "id",
+            "assignment",
+            "assigned_to",
+            "assigned_by",
+            "due_date",
+            "status",
+            "party",
+            "invoice_content_type",
+            "invoice_object_id",
+            "created_at",
+            "updated_at",
+        ]
+
+
+class DeliveryAssignmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DeliveryAssignment
+        fields = [
+            "id",
+            "employee",
+            "sale",
+            "assigned_date",
+            "status",
+            "remarks",
+        ]
+
+
+class LeaveBalanceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = LeaveBalance
+        fields = ["id", "employee", "annual", "sick", "casual"]
+
+
+class PayrollSlipSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PayrollSlip
+        fields = [
+            "id",
+            "employee",
+            "month",
+            "base_salary",
+            "present_days",
+            "absent_days",
+            "leaves_paid",
+            "deductions",
+            "net_salary",
+            "created_on",
+        ]

--- a/hr/urls.py
+++ b/hr/urls.py
@@ -1,0 +1,26 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import (
+    AttendanceViewSet,
+    DeliveryAssignmentViewSet,
+    EmployeeContractViewSet,
+    EmployeeViewSet,
+    LeaveBalanceViewSet,
+    LeaveRequestViewSet,
+    PayrollSlipViewSet,
+    SalesTargetViewSet,
+    TaskViewSet,
+)
+
+router = DefaultRouter()
+router.register(r'employees', EmployeeViewSet)
+router.register(r'contracts', EmployeeContractViewSet)
+router.register(r'leave-requests', LeaveRequestViewSet)
+router.register(r'attendance', AttendanceViewSet)
+router.register(r'sales-targets', SalesTargetViewSet)
+router.register(r'tasks', TaskViewSet)
+router.register(r'delivery-assignments', DeliveryAssignmentViewSet)
+router.register(r'leave-balances', LeaveBalanceViewSet)
+router.register(r'payroll-slips', PayrollSlipViewSet)
+
+urlpatterns = router.urls

--- a/hr/views.py
+++ b/hr/views.py
@@ -1,3 +1,80 @@
-from django.shortcuts import render
+from rest_framework import permissions, viewsets
 
-# Create your views here.
+from .models import (
+    Attendance,
+    DeliveryAssignment,
+    Employee,
+    EmployeeContract,
+    LeaveBalance,
+    LeaveRequest,
+    PayrollSlip,
+    SalesTarget,
+    Task,
+)
+from .serializers import (
+    AttendanceSerializer,
+    DeliveryAssignmentSerializer,
+    EmployeeContractSerializer,
+    EmployeeSerializer,
+    LeaveBalanceSerializer,
+    LeaveRequestSerializer,
+    PayrollSlipSerializer,
+    SalesTargetSerializer,
+    TaskSerializer,
+)
+
+
+class BaseViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class EmployeeViewSet(BaseViewSet):
+    queryset = Employee.objects.all()
+    serializer_class = EmployeeSerializer
+
+
+class EmployeeContractViewSet(BaseViewSet):
+    queryset = EmployeeContract.objects.all()
+    serializer_class = EmployeeContractSerializer
+
+
+class LeaveRequestViewSet(BaseViewSet):
+    queryset = LeaveRequest.objects.all()
+    serializer_class = LeaveRequestSerializer
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        employee_id = self.request.query_params.get("employee")
+        if employee_id:
+            qs = qs.filter(employee_id=employee_id)
+        return qs
+
+
+class AttendanceViewSet(BaseViewSet):
+    queryset = Attendance.objects.all()
+    serializer_class = AttendanceSerializer
+
+
+class SalesTargetViewSet(BaseViewSet):
+    queryset = SalesTarget.objects.all()
+    serializer_class = SalesTargetSerializer
+
+
+class TaskViewSet(BaseViewSet):
+    queryset = Task.objects.all()
+    serializer_class = TaskSerializer
+
+
+class DeliveryAssignmentViewSet(BaseViewSet):
+    queryset = DeliveryAssignment.objects.all()
+    serializer_class = DeliveryAssignmentSerializer
+
+
+class LeaveBalanceViewSet(BaseViewSet):
+    queryset = LeaveBalance.objects.all()
+    serializer_class = LeaveBalanceSerializer
+
+
+class PayrollSlipViewSet(BaseViewSet):
+    queryset = PayrollSlip.objects.all()
+    serializer_class = PayrollSlipSerializer


### PR DESCRIPTION
## Summary
- Implement DRF serializers, viewsets, and router for HR models and hook into project URLs.
- Expand frontend types and add hr service with CRUD helpers for employees, leave, tasks, and more.
- Refactor HR, MyLeave, and Tasks components to consume new API services and updated types.

## Testing
- `python manage.py test` *(fails: Application labels aren't unique, duplicates: rest_framework)*


------
https://chatgpt.com/codex/tasks/task_e_688fcc52a65883299bb3cff7da336bfb