### PR TITLE
feat: add sale invoice and return APIs

### DIFF
--- a/Frontend-PWD/components/CreditRecovery.tsx
+++ b/Frontend-PWD/components/CreditRecovery.tsx
@@ -51,6 +51,7 @@ const CreditRecovery: React.FC<CreditRecoveryProps> = ({ currentUser }) => {
 
         const newLog: RecoveryLog = {
             id: Date.now(),
+            invoiceId: Number(selectedOrder.id),
             date: new Date().toISOString(),
             notes: newNote,
             employeeId: currentUser.id,

--- a/Frontend-PWD/components/OrderManagement.tsx
+++ b/Frontend-PWD/components/OrderManagement.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Order, OrderStatus } from '../types';
-import { ORDERS } from '../constants';
+import { listSaleInvoices } from '../services/sale';
 import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
 
@@ -26,10 +26,15 @@ const StatusBadge: React.FC<{ status: OrderStatus }> = ({ status }) => {
 
 
 const OrderManagement: React.FC<OrderManagementProps> = ({ viewOrderDetails, handleEditSaleInvoice }) => {
+    const [orders, setOrders] = useState<Order[]>([]);
     const [searchTerm, setSearchTerm] = useState('');
     const [statusFilter, setStatusFilter] = useState<OrderStatus | 'All'>('All');
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
+
+    useEffect(() => {
+        listSaleInvoices().then(setOrders).catch(() => setOrders([]));
+    }, []);
 
     const resetFilters = () => {
         setSearchTerm('');
@@ -39,7 +44,7 @@ const OrderManagement: React.FC<OrderManagementProps> = ({ viewOrderDetails, han
     };
     
     const filteredOrders = useMemo(() => {
-        return ORDERS.filter(order => {
+        return orders.filter(order => {
             const searchLower = searchTerm.toLowerCase();
             const matchesSearch = searchTerm === '' ||
                 order.invoiceNo.toLowerCase().includes(searchLower) ||

--- a/Frontend-PWD/components/SaleInvoice.tsx
+++ b/Frontend-PWD/components/SaleInvoice.tsx
@@ -172,7 +172,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
       id: new Date().getTime().toString(),
       productId: null,
       batchId: null,
-      packing: '',
+      packing: 0,
       quantity: 1,
       bonus: 0,
       rate: 0,
@@ -314,7 +314,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
                                 <td className="p-1" style={{minWidth: '150px'}}><SearchableSelect options={(availableBatches.get(item.productId || 0) || []).map(b => ({ value: b.id, label: b.batchNo }))} value={item.batchId} onChange={val => handleItemChange(item.id, 'batchId', val)} disabled={!item.productId} /></td>
                                 <td className="p-1 text-sm text-gray-500 dark:text-gray-400" style={{minWidth: '110px'}}>{selectedBatch?.expiryDate || '-'}</td>
                                 <td className="p-1 text-sm text-gray-500 dark:text-gray-400">{selectedBatch?.stock || '-'}</td>
-                                <td className="p-1" style={{minWidth: '100px'}}><FormInput type="text" value={item.packing || ''} onChange={(e) => handleItemChange(item.id, 'packing', e.target.value)} placeholder="e.g. 10x10" /></td>
+                                <td className="p-1" style={{minWidth: '100px'}}><FormInput type="number" value={item.packing || 0} onChange={(e) => handleItemChange(item.id, 'packing', parseInt(e.target.value))} /></td>
                                 <td className="p-1" style={{minWidth: '80px'}}><FormInput type="number" value={item.quantity} onChange={(e) => handleItemChange(item.id, 'quantity', parseInt(e.target.value) || 0)} min="1" /></td>
                                 <td className="p-1" style={{minWidth: '80px'}}><FormInput type="number" value={item.bonus} onChange={(e) => handleItemChange(item.id, 'bonus', parseInt(e.target.value) || 0)} min="0" /></td>
                                 <td className="p-1 text-sm text-gray-500 dark:text-gray-400">{item.rate.toFixed(2)}</td>

--- a/Frontend-PWD/components/SaleReturnList.tsx
+++ b/Frontend-PWD/components/SaleReturnList.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Page, InvoiceStatus, SaleReturn } from '../types';
+import { Page, SaleReturn } from '../types';
 import { SALE_RETURNS, ICONS } from '../constants';
 import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
@@ -10,27 +10,13 @@ interface SaleReturnListProps {
   handleEditSaleReturn: (saleReturn: SaleReturn) => void;
 }
 
-const StatusBadge: React.FC<{ status: InvoiceStatus }> = ({ status }) => {
-    const colorClasses = {
-        Paid: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
-        Pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
-        Draft: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300',
-        Cancelled: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300',
-        Returned: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300',
-    }[status];
-    
-    return <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${colorClasses}`}>{status}</span>;
-};
-
 const SaleReturnList: React.FC<SaleReturnListProps> = ({ setCurrentPage, handleEditSaleReturn }) => {
     const [searchTerm, setSearchTerm] = useState('');
-    const [statusFilter, setStatusFilter] = useState('All');
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
 
     const resetFilters = () => {
         setSearchTerm('');
-        setStatusFilter('All');
         setStartDate('');
         setEndDate('');
     };
@@ -41,16 +27,14 @@ const SaleReturnList: React.FC<SaleReturnListProps> = ({ setCurrentPage, handleE
             const matchesSearch = searchTerm === '' ||
                 sReturn.returnNo.toLowerCase().includes(searchLower) ||
                 sReturn.customer?.name.toLowerCase().includes(searchLower);
-            
-            const matchesStatus = statusFilter === 'All' || sReturn.status === statusFilter;
-            
+
             const returnDate = new Date(sReturn.date);
             const matchesStartDate = startDate === '' || returnDate >= new Date(startDate);
             const matchesEndDate = endDate === '' || returnDate <= new Date(endDate);
 
-            return matchesSearch && matchesStatus && matchesStartDate && matchesEndDate;
+            return matchesSearch && matchesStartDate && matchesEndDate;
         });
-    }, [searchTerm, statusFilter, startDate, endDate]);
+    }, [searchTerm, startDate, endDate]);
     
     return (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
@@ -64,20 +48,12 @@ const SaleReturnList: React.FC<SaleReturnListProps> = ({ setCurrentPage, handleE
                     <span className="ml-2">Create New Return</span>
                 </button>
             </div>
-             <FilterBar>
+            <FilterBar>
                 <SearchInput
                     placeholder="Search by Return# or Customer..."
                     value={searchTerm}
                     onChange={e => setSearchTerm(e.target.value)}
                 />
-                <FilterControls.Select
-                    value={statusFilter}
-                    onChange={e => setStatusFilter(e.target.value)}
-                >
-                    <option value="All">All Statuses</option>
-                    <option value="Returned">Returned</option>
-                    <option value="Pending">Pending</option>
-                </FilterControls.Select>
                 <FilterControls.Input
                     type="date"
                     value={startDate}
@@ -98,7 +74,6 @@ const SaleReturnList: React.FC<SaleReturnListProps> = ({ setCurrentPage, handleE
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Customer</th>
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Date</th>
                             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Amount</th>
-                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Status</th>
                             <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Actions</th>
                         </tr>
                     </thead>
@@ -108,8 +83,7 @@ const SaleReturnList: React.FC<SaleReturnListProps> = ({ setCurrentPage, handleE
                                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{sReturn.returnNo}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{sReturn.customer?.name}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{sReturn.date}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">Rs. {sReturn.grandTotal.toFixed(2)}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm"><StatusBadge status={sReturn.status} /></td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">Rs. {sReturn.totalAmount.toFixed(2)}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                                     <button onClick={() => handleEditSaleReturn(sReturn)} className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300">View/Edit</button>
                                 </td>
@@ -117,7 +91,7 @@ const SaleReturnList: React.FC<SaleReturnListProps> = ({ setCurrentPage, handleE
                         ))}
                          {filteredReturns.length === 0 && (
                             <tr>
-                                <td colSpan={6} className="text-center py-12 text-gray-500">
+                                <td colSpan={5} className="text-center py-12 text-gray-500">
                                     No returns match your filters.
                                 </td>
                             </tr>

--- a/Frontend-PWD/constants.tsx
+++ b/Frontend-PWD/constants.tsx
@@ -210,18 +210,18 @@ export const PURCHASE_INVOICES: PurchaseInvoice[] = [
 
 
 export const ORDERS: Order[] = [
-    { id: '1', invoiceNo: 'INV-2024-001', userId: 101, cityId: 1, areaId: 1, customer: PARTIES_DATA[0], date: '2024-07-28', grandTotal: 2340.50, status: 'Delivered', items: [], subTotal: 2127.73, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyName: 'PharmaCo', qrCode: 'ORD-1-101-TS20240728', paymentMethod: 'Credit', paidAmount: 2000, recoveryLogs: [
-        {id: 1, date: '2024-08-01T10:00:00Z', notes: 'Called customer, payment promised by EOD.', employeeId: 203}
+    { id: '1', invoiceNo: 'INV-2024-001', customerId: 101, cityId: 1, areaId: 1, customer: PARTIES_DATA[0], date: '2024-07-28', grandTotal: 2340.50, status: 'Delivered', items: [], subTotal: 2127.73, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyInvoiceNumber: 'PharmaCo', qrCode: 'ORD-1-101-TS20240728', paymentMethod: 'Credit', paidAmount: 2000, recoveryLogs: [
+        {id: 1, invoiceId: 1, date: '2024-08-01T10:00:00Z', notes: 'Called customer, payment promised by EOD.', employeeId: 203}
     ] },
-    { id: '2', invoiceNo: 'INV-2024-002', userId: 102, cityId: 1, areaId: 2, customer: PARTIES_DATA[1], date: '2024-07-27', grandTotal: 880.00, status: 'Dispatched', items: [], subTotal: 800, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyName: 'PharmaCo', qrCode: 'ORD-2-102-TS20240727', paymentMethod: 'Credit', paidAmount: 0, recoveryLogs: [] },
-    { id: '3', invoiceNo: 'INV-2024-003', userId: 101, cityId: 2, areaId: 4, customer: PARTIES_DATA[0], date: '2024-07-26', grandTotal: 1560.75, status: 'Processing', items: [], subTotal: 1418.86, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyName: 'MedLife', qrCode: 'ORD-3-101-TS20240726', paymentMethod: 'Credit', paidAmount: 0, recoveryLogs: [] },
-    { id: '4', invoiceNo: 'INV-2024-004', userId: 102, cityId: 2, areaId: 5, customer: PARTIES_DATA[1], date: '2024-07-25', grandTotal: 540.00, status: 'Approved', items: [], subTotal: 490.91, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyName: 'MedLife', qrCode: 'ORD-4-102-TS20240725', paymentMethod: 'Cash', paidAmount: 540.00 },
-    { id: '5', invoiceNo: 'INV-2024-005', userId: 101, cityId: 3, areaId: 6, customer: PARTIES_DATA[0], date: '2024-07-29', grandTotal: 3150.00, status: 'Pending Approval', items: [], subTotal: 2863.64, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyName: 'PharmaCo', qrCode: null, paymentMethod: 'Credit', paidAmount: 0, recoveryLogs: [] }
+    { id: '2', invoiceNo: 'INV-2024-002', customerId: 102, cityId: 1, areaId: 2, customer: PARTIES_DATA[1], date: '2024-07-27', grandTotal: 880.00, status: 'Dispatched', items: [], subTotal: 800, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyInvoiceNumber: 'PharmaCo', qrCode: 'ORD-2-102-TS20240727', paymentMethod: 'Credit', paidAmount: 0, recoveryLogs: [] },
+    { id: '3', invoiceNo: 'INV-2024-003', customerId: 101, cityId: 2, areaId: 4, customer: PARTIES_DATA[0], date: '2024-07-26', grandTotal: 1560.75, status: 'Processing', items: [], subTotal: 1418.86, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyInvoiceNumber: 'MedLife', qrCode: 'ORD-3-101-TS20240726', paymentMethod: 'Credit', paidAmount: 0, recoveryLogs: [] },
+    { id: '4', invoiceNo: 'INV-2024-004', customerId: 102, cityId: 2, areaId: 5, customer: PARTIES_DATA[1], date: '2024-07-25', grandTotal: 540.00, status: 'Approved', items: [], subTotal: 490.91, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyInvoiceNumber: 'MedLife', qrCode: 'ORD-4-102-TS20240725', paymentMethod: 'Cash', paidAmount: 540.00, recoveryLogs: [] },
+    { id: '5', invoiceNo: 'INV-2024-005', customerId: 101, cityId: 3, areaId: 6, customer: PARTIES_DATA[0], date: '2024-07-29', grandTotal: 3150.00, status: 'Pending Approval', items: [], subTotal: 2863.64, discount: 0, tax: 10, supplyingManId: 2, bookingManId: 2, companyInvoiceNumber: 'PharmaCo', qrCode: null, paymentMethod: 'Credit', paidAmount: 0, recoveryLogs: [] }
 ];
 
 export const SALE_RETURNS: SaleReturn[] = [
-    { id: 'sr-1', returnNo: 'SRN-2024-001', customer: PARTIES_DATA[0], date: '2024-07-29', grandTotal: 210.00, status: 'Returned', items: [] },
-    { id: 'sr-2', returnNo: 'SRN-2024-002', customer: PARTIES_DATA[1], date: '2024-07-28', grandTotal: 150.75, status: 'Pending', items: [] }
+    { id: 'sr-1', returnNo: 'SRN-2024-001', customer: PARTIES_DATA[0], warehouseId: 1, date: '2024-07-29', totalAmount: 210.00, items: [] },
+    { id: 'sr-2', returnNo: 'SRN-2024-002', customer: PARTIES_DATA[1], warehouseId: 1, date: '2024-07-28', totalAmount: 150.75, items: [] }
 ];
 
 export const PURCHASE_RETURNS: PurchaseReturn[] = [

--- a/Frontend-PWD/services/sale.ts
+++ b/Frontend-PWD/services/sale.ts
@@ -1,0 +1,81 @@
+import { Order, SaleReturn } from '../types';
+
+const API_BASE = '/sales';
+
+export async function listSaleInvoices(): Promise<Order[]> {
+    const res = await fetch(`${API_BASE}/invoices/`);
+    if (!res.ok) throw new Error('Failed to fetch sale invoices');
+    return res.json();
+}
+
+export async function createSaleInvoice(invoice: Partial<Order>): Promise<Order> {
+    const payload = {
+        invoice_no: invoice.invoiceNo,
+        company_invoice_number: invoice.companyInvoiceNumber,
+        date: invoice.date,
+        customer: invoice.customerId ?? invoice.customer?.id,
+        warehouse: invoice.warehouseId,
+        salesman: invoice.salesmanId,
+        booking_man_id: invoice.bookingManId,
+        supplying_man_id: invoice.supplyingManId,
+        delivery_man_id: invoice.deliveryManId,
+        city_id: invoice.cityId,
+        area_id: invoice.areaId,
+        sub_total: invoice.subTotal,
+        discount: invoice.discount,
+        tax: invoice.tax,
+        grand_total: invoice.grandTotal,
+        paid_amount: invoice.paidAmount,
+        net_amount: invoice.netAmount ?? invoice.grandTotal,
+        payment_method: invoice.paymentMethod,
+        status: invoice.status,
+        qr_code: invoice.qrCode,
+        items: (invoice.items || []).map(it => ({
+            product: it.productId,
+            batch: it.batchId,
+            quantity: it.quantity,
+            bonus: it.bonus,
+            packing: it.packing || 0,
+            rate: it.rate,
+            discount1: it.discount1,
+            discount2: it.discount2,
+            amount: it.amount,
+            net_amount: it.netAmount,
+        })),
+    };
+    const res = await fetch(`${API_BASE}/invoices/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    if (!res.ok) throw new Error('Failed to create sale invoice');
+    return res.json();
+}
+
+export async function createSaleReturn(data: Partial<SaleReturn>): Promise<SaleReturn> {
+    const payload = {
+        return_no: data.returnNo,
+        date: data.date,
+        customer: data.customer?.id ?? data.customerId,
+        warehouse: data.warehouseId,
+        total_amount: data.totalAmount,
+        items: (data.items || []).map(it => ({
+            product: it.productId,
+            batch_number: it.batchNo,
+            expiry_date: it.expiryDate,
+            quantity: it.quantity,
+            rate: it.rate,
+            discount1: it.discount1 ?? 0,
+            discount2: it.discount2 ?? 0,
+            amount: it.amount,
+            net_amount: it.netAmount ?? it.amount,
+        })),
+    };
+    const res = await fetch(`${API_BASE}/returns/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    if (!res.ok) throw new Error('Failed to create sale return');
+    return res.json();
+}

--- a/Frontend-PWD/types.ts
+++ b/Frontend-PWD/types.ts
@@ -84,7 +84,7 @@ export interface InvoiceItem {
   id: string; // Temporary client-side ID
   productId: number | null;
   batchId: number | null;
-  packing?: string;
+  packing: number | null;
   bonus: number;
   quantity: number;
   rate: number;
@@ -109,34 +109,41 @@ export interface PurchaseInvoiceItem {
 
 export interface RecoveryLog {
     id: number;
+    invoiceId: number;
+    employeeId: number | null;
     date: string; // ISO Timestamp
     notes: string;
-    employeeId: number;
 }
 
 
 export interface Order {
-  id: string; // Changed from invoiceNo to be a unique ID
+  id: string;
   invoiceNo: string;
   status: OrderStatus;
-  userId: number; // The customer who placed the order
   customer: Party | null;
+  customerId?: number | null; // for API submissions
+  warehouseId?: number | null;
+  salesmanId?: number | null;
   cityId: number | null;
   areaId: number | null;
   supplyingManId: number | null;
   bookingManId: number | null;
   deliveryManId?: number | null;
-  companyName: string;
+  companyInvoiceNumber?: string;
   date: string;
   items: InvoiceItem[];
   subTotal: number;
   discount: number;
-  tax: number; // As a percentage
+  tax: number;
   grandTotal: number;
+  netAmount?: number;
+  paidAmount?: number;
   qrCode: string | null;
   paymentMethod: 'Cash' | 'Credit';
-  paidAmount?: number;
   recoveryLogs?: RecoveryLog[];
+  // Deprecated fields for backward compatibility
+  userId?: number;
+  companyName?: string;
 }
 
 
@@ -161,19 +168,25 @@ export interface SaleReturnItem {
     id: string; // temp client-side ID
     productId: number | null;
     batchNo: string;
+    expiryDate: string;
     quantity: number;
     rate: number;
+    discount1: number;
+    discount2: number;
     amount: number;
+    netAmount: number;
 }
 
 export interface SaleReturn {
     id: string;
     returnNo: string;
-    status: InvoiceStatus;
     customer: Party | null;
+    warehouseId: number | null;
     date: string;
     items: SaleReturnItem[];
-    grandTotal: number;
+    totalAmount: number;
+    // Deprecated for compatibility
+    status?: InvoiceStatus;
 }
 
 

--- a/sale/serializers.py
+++ b/sale/serializers.py
@@ -1,50 +1,133 @@
 from rest_framework import serializers
 
-from .models import SaleInvoice, SaleInvoiceItem
+from .models import (
+    SaleInvoice,
+    SaleInvoiceItem,
+    SaleReturn,
+    SaleReturnItem,
+    RecoveryLog,
+)
 
 
 class SaleInvoiceItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = SaleInvoiceItem
-        fields = ['product', 'quantity', 'rate', 'amount']
+        fields = [
+            "id",
+            "product",
+            "batch",
+            "quantity",
+            "bonus",
+            "packing",
+            "rate",
+            "discount1",
+            "discount2",
+            "amount",
+            "net_amount",
+        ]
+
+
+class RecoveryLogSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RecoveryLog
+        fields = ["id", "invoice", "employee", "date", "notes"]
 
 
 class SaleInvoiceSerializer(serializers.ModelSerializer):
-    items = SaleInvoiceItemSerializer(many=True, read_only=True)
+    items = SaleInvoiceItemSerializer(many=True)
+    recovery_logs = RecoveryLogSerializer(many=True, read_only=True)
 
     class Meta:
         model = SaleInvoice
         fields = [
-            'id',
-            'invoice_no',
-            'company_invoice_number',
-            'date',
-            'customer',
-            'warehouse',
-            'salesman',
-            'delivery_person',
-            'investor',
-            'total_amount',
-            'discount',
-            'tax',
-            'grand_total',
-            'payment_method',
-            'paid_amount',
-            'status',
-            'items',
+            "id",
+            "invoice_no",
+            "company_invoice_number",
+            "date",
+            "customer",
+            "warehouse",
+            "salesman",
+            "booking_man_id",
+            "supplying_man_id",
+            "delivery_man_id",
+            "city_id",
+            "area_id",
+            "sub_total",
+            "discount",
+            "tax",
+            "grand_total",
+            "paid_amount",
+            "net_amount",
+            "payment_method",
+            "status",
+            "qr_code",
+            "items",
+            "recovery_logs",
         ]
 
+    def create(self, validated_data):
+        items_data = validated_data.pop("items", [])
+        invoice = SaleInvoice.objects.create(**validated_data)
+        for item in items_data:
+            SaleInvoiceItem.objects.create(invoice=invoice, **item)
+        return invoice
+
     def validate(self, data):
-        total = data.get('total_amount') or 0
-        discount = data.get('discount') or 0
-        tax = data.get('tax') or 0
-        grand_total = data.get('grand_total') or 0
+        total = data.get("sub_total") or 0
+        discount = data.get("discount") or 0
+        tax = data.get("tax") or 0
+        grand_total = data.get("grand_total") or 0
         expected_grand_total = total - discount + tax
         if grand_total != expected_grand_total:
-            raise serializers.ValidationError({'grand_total': 'Grand total must equal total minus discount plus tax.'})
+            raise serializers.ValidationError(
+                {"grand_total": "Grand total must equal sub total minus discount plus tax."}
+            )
 
-        paid = data.get('paid_amount') or 0
+        paid = data.get("paid_amount") or 0
         if paid > grand_total:
-            raise serializers.ValidationError({'paid_amount': 'Paid amount cannot exceed grand total.'})
+            raise serializers.ValidationError(
+                {"paid_amount": "Paid amount cannot exceed grand total."}
+            )
         return data
+
+
+class SaleReturnItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SaleReturnItem
+        fields = [
+            "id",
+            "return_invoice",
+            "product",
+            "batch_number",
+            "expiry_date",
+            "quantity",
+            "rate",
+            "discount1",
+            "discount2",
+            "amount",
+            "net_amount",
+        ]
+
+
+class SaleReturnSerializer(serializers.ModelSerializer):
+    items = SaleReturnItemSerializer(many=True)
+
+    class Meta:
+        model = SaleReturn
+        fields = [
+            "id",
+            "return_no",
+            "date",
+            "customer",
+            "warehouse",
+            "total_amount",
+            "items",
+        ]
+
+    def create(self, validated_data):
+        items_data = validated_data.pop("items", [])
+        sr = SaleReturn.objects.create(**validated_data)
+        for item in items_data:
+            SaleReturnItem.objects.create(return_invoice=sr, **item)
+        return sr
 

--- a/sale/urls.py
+++ b/sale/urls.py
@@ -1,9 +1,26 @@
 from django.urls import path
-from . import views
+from rest_framework.routers import DefaultRouter
 
-urlpatterns = [
-    path('', views.sale_invoice_list, name='sale_list'),
-    path('create/', views.sale_invoice_create, name='sale_create'),
-    path('<int:pk>/edit/', views.sale_invoice_edit, name='sale_edit'),
-    path('<int:pk>/', views.sale_invoice_detail, name='sale_detail'),
+from .views import (
+    sale_invoice_list,
+    sale_invoice_create,
+    sale_invoice_edit,
+    sale_invoice_detail,
+    SaleInvoiceViewSet,
+    SaleReturnViewSet,
+    SaleReturnItemViewSet,
+    RecoveryLogViewSet,
+)
+
+router = DefaultRouter()
+router.register(r'invoices', SaleInvoiceViewSet)
+router.register(r'returns', SaleReturnViewSet)
+router.register(r'return-items', SaleReturnItemViewSet)
+router.register(r'recovery-logs', RecoveryLogViewSet)
+
+urlpatterns = router.urls + [
+    path('', sale_invoice_list, name='sale_list'),
+    path('create/', sale_invoice_create, name='sale_create'),
+    path('<int:pk>/edit/', sale_invoice_edit, name='sale_edit'),
+    path('<int:pk>/', sale_invoice_detail, name='sale_detail'),
 ]

--- a/sale/views.py
+++ b/sale/views.py
@@ -3,8 +3,22 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.urls import reverse
 from django.contrib import messages
 from django.views.decorators.http import require_http_methods
-from .models import SaleInvoice, SaleInvoiceItem
-from .forms import SaleInvoiceForm,SaleInvoiceItemForm
+from rest_framework import viewsets
+
+from .models import (
+    SaleInvoice,
+    SaleInvoiceItem,
+    SaleReturn,
+    SaleReturnItem,
+    RecoveryLog,
+)
+from .forms import SaleInvoiceForm, SaleInvoiceItemForm
+from .serializers import (
+    SaleInvoiceSerializer,
+    SaleReturnSerializer,
+    SaleReturnItemSerializer,
+    RecoveryLogSerializer,
+)
 
 
 @require_http_methods(["GET"])
@@ -72,3 +86,23 @@ def sale_invoice_detail(request, pk):
         pk=pk,
     )
     return render(request, 'invoice/sale_detail.html', {'sale': invoice})
+
+
+class SaleInvoiceViewSet(viewsets.ModelViewSet):
+    queryset = SaleInvoice.objects.all().prefetch_related('items', 'recovery_logs')
+    serializer_class = SaleInvoiceSerializer
+
+
+class SaleReturnViewSet(viewsets.ModelViewSet):
+    queryset = SaleReturn.objects.all().prefetch_related('items')
+    serializer_class = SaleReturnSerializer
+
+
+class SaleReturnItemViewSet(viewsets.ModelViewSet):
+    queryset = SaleReturnItem.objects.all()
+    serializer_class = SaleReturnItemSerializer
+
+
+class RecoveryLogViewSet(viewsets.ModelViewSet):
+    queryset = RecoveryLog.objects.all()
+    serializer_class = RecoveryLogSerializer


### PR DESCRIPTION
## Summary
- build serializers for sale invoices, sale returns and recovery logs
- expose viewsets and routes for sale operations
- sync frontend models and add sale services

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688fcc590e7083298e7114f943e82ffa