### PR TITLE
Implement purchase APIs and frontend services

### DIFF
--- a/Frontend-PWD/components/PurchaseInvoiceList.tsx
+++ b/Frontend-PWD/components/PurchaseInvoiceList.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Page, InvoiceStatus, PurchaseInvoice } from '../types';
-import { PURCHASE_INVOICES, ICONS } from '../constants';
+import { ICONS } from '../constants';
+import { fetchPurchaseInvoices } from '../services/purchase';
 import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
 
@@ -22,6 +23,10 @@ const StatusBadge: React.FC<{ status: InvoiceStatus }> = ({ status }) => {
 };
 
 const PurchaseInvoiceList: React.FC<PurchaseInvoiceListProps> = ({ setCurrentPage, handleEditPurchaseInvoice }) => {
+    const [invoices, setInvoices] = useState<PurchaseInvoice[]>([]);
+    useEffect(() => {
+        fetchPurchaseInvoices().then(setInvoices).catch(console.error);
+    }, []);
     const [searchTerm, setSearchTerm] = useState('');
     const [statusFilter, setStatusFilter] = useState('All');
     const [startDate, setStartDate] = useState('');
@@ -35,7 +40,7 @@ const PurchaseInvoiceList: React.FC<PurchaseInvoiceListProps> = ({ setCurrentPag
     };
 
     const filteredInvoices = useMemo(() => {
-        return PURCHASE_INVOICES.filter(invoice => {
+        return invoices.filter(invoice => {
             const searchLower = searchTerm.toLowerCase();
             const matchesSearch = searchTerm === '' ||
                 invoice.invoiceNo.toLowerCase().includes(searchLower) ||
@@ -50,7 +55,7 @@ const PurchaseInvoiceList: React.FC<PurchaseInvoiceListProps> = ({ setCurrentPag
 
             return matchesSearch && matchesStatus && matchesStartDate && matchesEndDate;
         });
-    }, [searchTerm, statusFilter, startDate, endDate]);
+    }, [invoices, searchTerm, statusFilter, startDate, endDate]);
 
     return (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow">

--- a/Frontend-PWD/components/PurchaseReturn.tsx
+++ b/Frontend-PWD/components/PurchaseReturn.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { PurchaseReturn, PurchaseReturnItem } from '../types';
 import { SUPPLIERS, PRODUCTS, ICONS } from '../constants';
 import SearchableSelect from './SearchableSelect';
-import { addToSyncQueue, registerSync } from '../services/db';
+import { createPurchaseReturn, updatePurchaseReturn } from '../services/purchase';
 
 interface PurchaseReturnProps {
   returnToEdit: PurchaseReturn | null;
@@ -16,17 +16,16 @@ const FormInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({...pr
 const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handleClose }) => {
   const [pReturn, setPReturn] = useState<Omit<PurchaseReturn, 'supplier' | 'id'>>({
     returnNo: `PRN-${Math.floor(Math.random() * 10000)}`,
-    status: 'Draft',
     date: new Date().toISOString().split('T')[0],
     items: [],
-    grandTotal: 0,
+    totalAmount: 0,
   });
   const [supplierId, setSupplierId] = useState<number | null>(null);
-  
+
   const isEditMode = useMemo(() => !!returnToEdit, [returnToEdit]);
 
   useEffect(() => {
-    if (isEditMode) {
+    if (isEditMode && returnToEdit) {
       const { supplier, ...rest } = returnToEdit;
       setPReturn(rest);
       setSupplierId(supplier?.id || null);
@@ -34,26 +33,37 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
   }, [returnToEdit, isEditMode]);
 
   useEffect(() => {
-    const grandTotal = pReturn.items.reduce((acc, item) => acc + item.amount, 0);
-    setPReturn(prev => ({ ...prev, grandTotal }));
+    const totalAmount = pReturn.items.reduce((acc, item) => acc + item.amount, 0);
+    setPReturn(prev => ({ ...prev, totalAmount }));
   }, [pReturn.items]);
 
   const handleAddItem = () => {
-    const newItem: PurchaseReturnItem = { id: Date.now().toString(), productId: null, batchNo: '', quantity: 1, rate: 0, amount: 0 };
+    const newItem: PurchaseReturnItem = {
+      id: Date.now().toString(),
+      productId: null,
+      batchNo: '',
+      expiryDate: '',
+      quantity: 1,
+      purchasePrice: 0,
+      salePrice: 0,
+      amount: 0,
+    };
     setPReturn(prev => ({ ...prev, items: [...prev.items, newItem] }));
   };
-  
-  const handleRemoveItem = (id: string) => { setPReturn(prev => ({ ...prev, items: prev.items.filter(item => item.id !== id) })); };
+
+  const handleRemoveItem = (id: string) => {
+    setPReturn(prev => ({ ...prev, items: prev.items.filter(item => item.id !== id) }));
+  };
 
   const handleItemChange = (id: string, field: keyof PurchaseReturnItem, value: any) => {
     const newItems = pReturn.items.map(item => {
       if (item.id === id) {
         const updatedItem = { ...item, [field]: value };
         if (field === 'productId') {
-            const product = PRODUCTS.find(p => p.id === Number(value));
-            updatedItem.rate = product ? product.tradePrice : 0;
+          const product = PRODUCTS.find(p => p.id === Number(value));
+          updatedItem.purchasePrice = product ? product.tradePrice : 0;
         }
-        updatedItem.amount = updatedItem.quantity * updatedItem.rate;
+        updatedItem.amount = updatedItem.quantity * updatedItem.purchasePrice;
         return updatedItem;
       }
       return item;
@@ -62,77 +72,77 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
   };
 
   const handleSubmit = async () => {
-    const finalReturn: PurchaseReturn = { 
-        id: isEditMode ? returnToEdit.id : new Date().getTime().toString(),
-        ...pReturn, 
-        supplier: SUPPLIERS.find(s => s.id === supplierId) || null 
+    const finalReturn: PurchaseReturn = {
+      id: isEditMode ? returnToEdit!.id : new Date().getTime().toString(),
+      ...pReturn,
+      supplier: SUPPLIERS.find(s => s.id === supplierId) || null,
     };
 
-    const endpoint = isEditMode ? `/api/purchase-returns/${finalReturn.id}` : '/api/purchase-returns';
-    const method = isEditMode ? 'PUT' : 'POST';
-
-    await addToSyncQueue({ endpoint, method, payload: finalReturn });
-    await registerSync();
+    if (isEditMode) {
+      await updatePurchaseReturn(finalReturn.id, finalReturn);
+    } else {
+      await createPurchaseReturn(finalReturn);
+    }
     handleClose();
   };
-  
+
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 md:p-8 space-y-6">
-        <fieldset className="p-4 border dark:border-gray-700 rounded-md">
-            <legend className="px-2 text-lg font-semibold">Return Details</legend>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div><label className="block text-sm font-medium mb-1">Supplier</label><SearchableSelect options={SUPPLIERS.map(s => ({value: s.id, label: s.name}))} value={supplierId} onChange={val => setSupplierId(val as number)} /></div>
-                <div><label className="block text-sm font-medium mb-1">Return Date</label><FormInput type="date" value={pReturn.date} onChange={(e) => setPReturn(prev => ({ ...prev, date: e.target.value }))} /></div>
-                <div><label className="block text-sm font-medium mb-1">Return #</label><FormInput type="text" readOnly value={pReturn.returnNo} className="bg-gray-100 dark:bg-gray-700" /></div>
-            </div>
-        </fieldset>
-
-        <fieldset className="p-4 border dark:border-gray-700 rounded-md">
-            <legend className="px-2 text-lg font-semibold">Return Items</legend>
-            <div className="overflow-x-auto w-full">
-                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                    <thead className="bg-gray-50 dark:bg-gray-700">
-                        <tr>
-                            <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Product</th>
-                            <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Batch No</th>
-                            <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Qty</th>
-                            <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Rate</th>
-                            <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Amount</th>
-                            <th className="w-12"></th>
-                        </tr>
-                    </thead>
-                    <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-600">
-                        {pReturn.items.map(item => (
-                        <tr key={item.id}>
-                            <td className="p-1" style={{minWidth: '250px'}}><SearchableSelect options={PRODUCTS.map(p => ({value: p.id, label: p.name}))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
-                            <td className="p-1"><FormInput type="text" placeholder="Batch No." value={item.batchNo} onChange={(e) => handleItemChange(item.id, 'batchNo', e.target.value)} style={{minWidth: '120px'}} /></td>
-                            <td className="p-1"><FormInput type="number" value={item.quantity} onChange={(e) => handleItemChange(item.id, 'quantity', parseInt(e.target.value))} min="1" style={{width: '100px'}} /></td>
-                            <td className="p-1"><FormInput type="number" value={item.rate} onChange={(e) => handleItemChange(item.id, 'rate', parseFloat(e.target.value))} min="0" step="0.01" style={{width: '120px'}}/></td>
-                            <td className="px-2 py-2 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{item.amount.toFixed(2)}</td>
-                            <td className="p-1 text-center"><button onClick={() => handleRemoveItem(item.id)} className="text-red-500 hover:text-red-700 dark:hover:text-red-400 p-1">{ICONS.trash}</button></td>
-                        </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-            <div className="mt-4"><button onClick={handleAddItem} className="flex items-center text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{ICONS.plus}<span className="ml-2">Add Item</span></button></div>
-        </fieldset>
-
-        <div className="flex justify-end">
-            <div className="w-full max-w-sm space-y-3">
-                <div className="border-t border-gray-200 dark:border-gray-600 my-2"></div>
-                <div className="flex justify-between text-lg font-bold">
-                    <span className="text-gray-900 dark:text-white">Grand Total:</span>
-                    <span className="text-blue-600 dark:text-blue-400">Rs. {pReturn.grandTotal.toFixed(2)}</span>
-                </div>
-            </div>
+      <fieldset className="p-4 border dark:border-gray-700 rounded-md">
+        <legend className="px-2 text-lg font-semibold">Return Details</legend>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div><label className="block text-sm font-medium mb-1">Supplier</label><SearchableSelect options={SUPPLIERS.map(s => ({value: s.id, label: s.name}))} value={supplierId} onChange={val => setSupplierId(val as number)} /></div>
+          <div><label className="block text-sm font-medium mb-1">Return Date</label><FormInput type="date" value={pReturn.date} onChange={(e) => setPReturn(prev => ({ ...prev, date: e.target.value }))} /></div>
+          <div><label className="block text-sm font-medium mb-1">Return #</label><FormInput type="text" readOnly value={pReturn.returnNo} className="bg-gray-100 dark:bg-gray-700" /></div>
         </div>
-       <div className="mt-8 flex justify-end space-x-4">
-            <button onClick={handleClose} className="px-6 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">Close</button>
-            <button onClick={handleSubmit} className="px-6 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700">
-              {isEditMode ? 'Update & Sync' : 'Submit & Sync'}
-            </button>
+      </fieldset>
+
+      <fieldset className="p-4 border dark:border-gray-700 rounded-md">
+        <legend className="px-2 text-lg font-semibold">Return Items</legend>
+        <div className="overflow-x-auto w-full">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="bg-gray-50 dark:bg-gray-700">
+              <tr>
+                <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Product</th>
+                <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Batch No</th>
+                <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Qty</th>
+                <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Rate</th>
+                <th className="px-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Amount</th>
+                <th className="w-12"></th>
+              </tr>
+            </thead>
+            <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-600">
+              {pReturn.items.map(item => (
+                <tr key={item.id}>
+                  <td className="p-1" style={{minWidth: '250px'}}><SearchableSelect options={PRODUCTS.map(p => ({value: p.id, label: p.name}))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
+                  <td className="p-1"><FormInput type="text" placeholder="Batch No." value={item.batchNo} onChange={(e) => handleItemChange(item.id, 'batchNo', e.target.value)} style={{minWidth: '120px'}} /></td>
+                  <td className="p-1"><FormInput type="number" value={item.quantity} onChange={(e) => handleItemChange(item.id, 'quantity', parseInt(e.target.value))} min="1" style={{width: '100px'}} /></td>
+                  <td className="p-1"><FormInput type="number" value={item.purchasePrice} onChange={(e) => handleItemChange(item.id, 'purchasePrice', parseFloat(e.target.value))} min="0" step="0.01" style={{width: '120px'}}/></td>
+                  <td className="px-2 py-2 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{item.amount.toFixed(2)}</td>
+                  <td className="p-1 text-center"><button onClick={() => handleRemoveItem(item.id)} className="text-red-500 hover:text-red-700 dark:hover:text-red-400 p-1">{ICONS.trash}</button></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
+        <div className="mt-4"><button onClick={handleAddItem} className="flex items-center text-sm font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{ICONS.plus}<span className="ml-2">Add Item</span></button></div>
+      </fieldset>
+
+      <div className="flex justify-end">
+        <div className="w-full max-w-sm space-y-3">
+          <div className="border-t border-gray-200 dark:border-gray-600 my-2"></div>
+          <div className="flex justify-between text-lg font-bold">
+            <span className="text-gray-900 dark:text-white">Grand Total:</span>
+            <span className="text-blue-600 dark:text-blue-400">Rs. {pReturn.totalAmount.toFixed(2)}</span>
+          </div>
+        </div>
+      </div>
+      <div className="mt-8 flex justify-end space-x-4">
+        <button onClick={handleClose} className="px-6 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700">Close</button>
+        <button onClick={handleSubmit} className="px-6 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700">
+          {isEditMode ? 'Update & Sync' : 'Submit & Sync'}
+        </button>
+      </div>
     </div>
   );
 };

--- a/Frontend-PWD/components/PurchaseReturnList.tsx
+++ b/Frontend-PWD/components/PurchaseReturnList.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Page, InvoiceStatus, PurchaseReturn } from '../types';
-import { PURCHASE_RETURNS, ICONS } from '../constants';
+import { ICONS } from '../constants';
+import { fetchPurchaseReturns } from '../services/purchase';
 import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
 
@@ -22,6 +23,10 @@ const StatusBadge: React.FC<{ status: InvoiceStatus }> = ({ status }) => {
 };
 
 const PurchaseReturnList: React.FC<PurchaseReturnListProps> = ({ setCurrentPage, handleEditPurchaseReturn }) => {
+    const [returns, setReturns] = useState<PurchaseReturn[]>([]);
+    useEffect(() => {
+        fetchPurchaseReturns().then(setReturns).catch(console.error);
+    }, []);
     const [searchTerm, setSearchTerm] = useState('');
     const [statusFilter, setStatusFilter] = useState('All');
     const [startDate, setStartDate] = useState('');
@@ -35,7 +40,7 @@ const PurchaseReturnList: React.FC<PurchaseReturnListProps> = ({ setCurrentPage,
     };
 
     const filteredReturns = useMemo(() => {
-        return PURCHASE_RETURNS.filter(pReturn => {
+        return returns.filter(pReturn => {
             const searchLower = searchTerm.toLowerCase();
             const matchesSearch = searchTerm === '' ||
                 pReturn.returnNo.toLowerCase().includes(searchLower) ||
@@ -49,7 +54,7 @@ const PurchaseReturnList: React.FC<PurchaseReturnListProps> = ({ setCurrentPage,
 
             return matchesSearch && matchesStatus && matchesStartDate && matchesEndDate;
         });
-    }, [searchTerm, statusFilter, startDate, endDate]);
+    }, [returns, searchTerm, statusFilter, startDate, endDate]);
 
     return (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
@@ -107,7 +112,7 @@ const PurchaseReturnList: React.FC<PurchaseReturnListProps> = ({ setCurrentPage,
                                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{pReturn.returnNo}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{pReturn.supplier?.name}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{pReturn.date}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">Rs. {pReturn.grandTotal.toFixed(2)}</td>
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">Rs. {pReturn.totalAmount.toFixed(2)}</td>
                                 <td className="px-6 py-4 whitespace-nowrap text-sm"><StatusBadge status={pReturn.status} /></td>
                                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                                     <button onClick={() => handleEditPurchaseReturn(pReturn)} className="text-blue-600 hover:text-blue-900 dark:text-blue-400 dark:hover:text-blue-300">View/Edit</button>

--- a/Frontend-PWD/services/purchase.ts
+++ b/Frontend-PWD/services/purchase.ts
@@ -1,0 +1,41 @@
+import { PurchaseInvoice, PurchaseReturn, InvestorTransaction } from '../types';
+
+const API_BASE = '/purchase';
+
+async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(url, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+
+// Purchase Invoices
+export const fetchPurchaseInvoices = () => request<PurchaseInvoice[]>(`${API_BASE}/invoices/`);
+export const createPurchaseInvoice = (data: Partial<PurchaseInvoice>) =>
+  request<PurchaseInvoice>(`${API_BASE}/invoices/`, { method: 'POST', body: JSON.stringify(data) });
+export const updatePurchaseInvoice = (id: number | string, data: Partial<PurchaseInvoice>) =>
+  request<PurchaseInvoice>(`${API_BASE}/invoices/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deletePurchaseInvoice = (id: number | string) =>
+  request<void>(`${API_BASE}/invoices/${id}/`, { method: 'DELETE' });
+
+// Purchase Returns
+export const fetchPurchaseReturns = () => request<PurchaseReturn[]>(`${API_BASE}/returns/`);
+export const createPurchaseReturn = (data: Partial<PurchaseReturn>) =>
+  request<PurchaseReturn>(`${API_BASE}/returns/`, { method: 'POST', body: JSON.stringify(data) });
+export const updatePurchaseReturn = (id: number | string, data: Partial<PurchaseReturn>) =>
+  request<PurchaseReturn>(`${API_BASE}/returns/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deletePurchaseReturn = (id: number | string) =>
+  request<void>(`${API_BASE}/returns/${id}/`, { method: 'DELETE' });
+
+// Investor Transactions
+export const fetchInvestorTransactions = () => request<InvestorTransaction[]>(`${API_BASE}/investor-transactions/`);
+export const createInvestorTransaction = (data: Partial<InvestorTransaction>) =>
+  request<InvestorTransaction>(`${API_BASE}/investor-transactions/`, { method: 'POST', body: JSON.stringify(data) });
+export const updateInvestorTransaction = (id: number | string, data: Partial<InvestorTransaction>) =>
+  request<InvestorTransaction>(`${API_BASE}/investor-transactions/${id}/`, { method: 'PUT', body: JSON.stringify(data) });
+export const deleteInvestorTransaction = (id: number | string) =>
+  request<void>(`${API_BASE}/investor-transactions/${id}/`, { method: 'DELETE' });

--- a/Frontend-PWD/types.ts
+++ b/Frontend-PWD/types.ts
@@ -101,9 +101,10 @@ export interface PurchaseInvoiceItem {
     expiryDate: string;
     quantity: number;
     bonus: number;
-    rate: number;
+    purchasePrice: number;
+    salePrice: number;
     discount: number; // percentage
-    amount: number; // qty * rate
+    amount: number; // qty * purchasePrice
     netAmount: number; // amount after discount
 }
 
@@ -145,10 +146,11 @@ export interface PurchaseInvoice {
   invoiceNo: string;
   status: InvoiceStatus;
   supplier: Supplier | null;
+  warehouseId?: number;
   date: string;
   companyInvoiceNumber: string;
   items: PurchaseInvoiceItem[];
-  subTotal: number;
+  totalAmount: number;
   discount: number; // As a percentage for the whole invoice
   tax: number; // As a percentage
   grandTotal: number;
@@ -181,19 +183,22 @@ export interface PurchaseReturnItem {
     id: string; // temp client-side ID
     productId: number | null;
     batchNo: string;
+    expiryDate: string;
     quantity: number;
-    rate: number;
+    purchasePrice: number;
+    salePrice: number;
     amount: number;
 }
 
 export interface PurchaseReturn {
     id: string;
     returnNo: string;
-    status: InvoiceStatus;
     supplier: Supplier | null;
+    warehouseId?: number;
     date: string;
     items: PurchaseReturnItem[];
-    grandTotal: number;
+    totalAmount: number;
+    status?: InvoiceStatus;
 }
 
 
@@ -412,16 +417,16 @@ export interface Task {
 }
 
 // Investor Module Types
-export type InvestorTransactionType = 'INVESTMENT' | 'PAYOUT' | 'PROFIT_SHARE';
+export type InvestorTransactionType = 'investment' | 'payout' | 'profit';
 
 export interface InvestorTransaction {
     id: number;
     investorId: number;
-    type: InvestorTransactionType;
+    transactionType: InvestorTransactionType;
     amount: number;
     date: string; // YYYY-MM-DD
     notes?: string;
-    relatedPurchaseInvoiceId?: string;
+    purchaseInvoiceId?: number;
 }
 
 // Offline Sync Type

--- a/purchase/serializers.py
+++ b/purchase/serializers.py
@@ -1,0 +1,42 @@
+from rest_framework import serializers
+from .models import (
+    PurchaseInvoice,
+    PurchaseInvoiceItem,
+    PurchaseReturn,
+    PurchaseReturnItem,
+    InvestorTransaction,
+)
+
+
+class PurchaseInvoiceItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PurchaseInvoiceItem
+        fields = "__all__"
+
+
+class PurchaseInvoiceSerializer(serializers.ModelSerializer):
+    items = PurchaseInvoiceItemSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = PurchaseInvoice
+        fields = "__all__"
+
+
+class PurchaseReturnItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PurchaseReturnItem
+        fields = "__all__"
+
+
+class PurchaseReturnSerializer(serializers.ModelSerializer):
+    items = PurchaseReturnItemSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = PurchaseReturn
+        fields = "__all__"
+
+
+class InvestorTransactionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = InvestorTransaction
+        fields = "__all__"

--- a/purchase/urls.py
+++ b/purchase/urls.py
@@ -1,7 +1,13 @@
-from django.urls import path
-from . import views
+from rest_framework.routers import DefaultRouter
+from .views import (
+    PurchaseInvoiceViewSet,
+    PurchaseReturnViewSet,
+    InvestorTransactionViewSet,
+)
 
-urlpatterns = [
-    path('investor-transactions/', views.investor_transaction_list, name='investortransaction_list'),
-    path('investor-transactions/<int:pk>/', views.investor_transaction_detail, name='investortransaction_detail'),
-]
+router = DefaultRouter()
+router.register(r'invoices', PurchaseInvoiceViewSet)
+router.register(r'returns', PurchaseReturnViewSet)
+router.register(r'investor-transactions', InvestorTransactionViewSet)
+
+urlpatterns = router.urls

--- a/purchase/views.py
+++ b/purchase/views.py
@@ -1,83 +1,23 @@
-import json
-from decimal import Decimal
+from rest_framework import viewsets
 
-from django.http import JsonResponse
-from django.shortcuts import get_object_or_404, render
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods
-
-from inventory.models import Party
-
-from .models import InvestorTransaction, PurchaseInvoice
+from .models import PurchaseInvoice, PurchaseReturn, InvestorTransaction
+from .serializers import (
+    PurchaseInvoiceSerializer,
+    PurchaseReturnSerializer,
+    InvestorTransactionSerializer,
+)
 
 
-# API endpoints for investor transactions
+class PurchaseInvoiceViewSet(viewsets.ModelViewSet):
+    queryset = PurchaseInvoice.objects.all()
+    serializer_class = PurchaseInvoiceSerializer
 
 
-def _serialize_transaction(tx: InvestorTransaction) -> dict:
-    return {
-        "id": tx.id,
-        "investor": tx.investor_id,
-        "transaction_type": tx.transaction_type,
-        "amount": str(tx.amount),
-        "date": tx.date.isoformat(),
-        "notes": tx.notes,
-        "purchase_invoice": tx.purchase_invoice_id,
-    }
+class PurchaseReturnViewSet(viewsets.ModelViewSet):
+    queryset = PurchaseReturn.objects.all()
+    serializer_class = PurchaseReturnSerializer
 
 
-@csrf_exempt
-@require_http_methods(["GET", "POST"])
-def investor_transaction_list(request):
-    """List all transactions or create a new one."""
-
-    if request.method == "GET":
-        data = [_serialize_transaction(tx) for tx in InvestorTransaction.objects.all()]
-        return JsonResponse(data, safe=False)
-
-    payload = json.loads(request.body or "{}")
-    investor = get_object_or_404(Party, pk=payload.get("investor"))
-    invoice = None
-    if payload.get("purchase_invoice"):
-        invoice = get_object_or_404(PurchaseInvoice, pk=payload["purchase_invoice"])
-    tx = InvestorTransaction.objects.create(
-        investor=investor,
-        transaction_type=payload.get("transaction_type"),
-        amount=Decimal(str(payload.get("amount", "0"))),
-        date=payload.get("date"),
-        notes=payload.get("notes", ""),
-        purchase_invoice=invoice,
-    )
-    return JsonResponse(_serialize_transaction(tx), status=201)
-
-
-@csrf_exempt
-@require_http_methods(["GET", "PUT", "DELETE"])
-def investor_transaction_detail(request, pk: int):
-    """Retrieve, update or delete a transaction."""
-
-    tx = get_object_or_404(InvestorTransaction, pk=pk)
-
-    if request.method == "GET":
-        return JsonResponse(_serialize_transaction(tx))
-
-    if request.method == "DELETE":
-        tx.delete()
-        return JsonResponse({}, status=204)
-
-    payload = json.loads(request.body or "{}")
-    if "investor" in payload:
-        tx.investor = get_object_or_404(Party, pk=payload["investor"])
-    if "purchase_invoice" in payload:
-        invoice_id = payload["purchase_invoice"]
-        tx.purchase_invoice = (
-            get_object_or_404(PurchaseInvoice, pk=invoice_id) if invoice_id else None
-        )
-    for field in ["transaction_type", "date", "notes"]:
-        if field in payload:
-            setattr(tx, field, payload[field])
-    if "amount" in payload:
-        tx.amount = Decimal(str(payload["amount"]))
-    tx.save()
-    return JsonResponse(_serialize_transaction(tx))
-
+class InvestorTransactionViewSet(viewsets.ModelViewSet):
+    queryset = InvestorTransaction.objects.all()
+    serializer_class = InvestorTransactionSerializer


### PR DESCRIPTION
## Summary
- add REST serializers and viewsets for purchase invoices, returns and investor transactions
- expose purchase endpoints with DRF router
- expand frontend types and create purchase service layer
- refactor purchase components to use new services

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'unfold.contrib')*

------
https://chatgpt.com/codex/tasks/task_e_688fcc5ac0fc8329991c4358d4e1dc2a