### PR TITLE
feat: add delivery assignments management page

### DIFF
--- a/Frontend-PWD/App.tsx
+++ b/Frontend-PWD/App.tsx
@@ -27,6 +27,7 @@ import MyOrders from './components/MyOrders';
 import OrderDetail from './components/OrderDetail';
 import CRM from './components/CRM';
 import Tasks from './components/Tasks';
+import DeliveryAssignments from './components/DeliveryAssignments';
 import { NOTIFICATIONS } from './constants';
 import RecoveryOfficerDashboard from './components/RecoveryOfficerDashboard';
 import CreditRecovery from './components/CreditRecovery';
@@ -193,6 +194,7 @@ const App: React.FC = () => {
             <Route path={ROUTES.hr.path} element={<HR />} />
             <Route path={ROUTES.crm.path} element={<CRM />} />
             <Route path={ROUTES.tasks.path} element={<Tasks currentUser={currentUser} />} />
+            <Route path={ROUTES['delivery-assignments'].path} element={<DeliveryAssignments />} />
             <Route path={ROUTES.management.path} element={<Management />} />
             <Route path={ROUTES.expenses.path} element={<Expenses />} />
             <Route path={ROUTES['my-leave'].path} element={<MyLeave currentUser={currentUser} />} />

--- a/Frontend-PWD/components/DeliveryAssignments.tsx
+++ b/Frontend-PWD/components/DeliveryAssignments.tsx
@@ -1,0 +1,207 @@
+import React, { useEffect, useState } from 'react';
+import { DeliveryAssignment, Employee, Order } from '../types';
+import {
+    getDeliveryAssignments,
+    createDeliveryAssignment,
+    updateDeliveryAssignment,
+    deleteDeliveryAssignment,
+    getEmployees,
+} from '../services/hr';
+import { listSaleInvoices } from '../services/sale';
+import SearchableSelect from './SearchableSelect';
+
+const AssignmentForm: React.FC<{
+    assignment: Partial<DeliveryAssignment> | null;
+    employees: Employee[];
+    sales: Order[];
+    onSave: (data: Partial<DeliveryAssignment>) => void;
+    onClose: () => void;
+}> = ({ assignment, employees, sales, onSave, onClose }) => {
+    const [formData, setFormData] = useState<Partial<DeliveryAssignment>>(assignment || { status: 'ASSIGNED' });
+
+    const handleChange = (name: string, value: any) => {
+        setFormData(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleInputChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => {
+        handleChange(e.target.name, e.target.value);
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        onSave(formData);
+    };
+
+    const employeeOptions = employees.map(e => ({ value: e.id, label: e.name }));
+    const saleOptions = sales.map(s => ({ value: s.id, label: s.invoiceNo }));
+    const statusOptions = ['ASSIGNED', 'DELIVERED', 'FAILED'].map(s => ({ value: s, label: s }));
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center p-4">
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-lg">
+                <form onSubmit={handleSubmit}>
+                    <div className="p-6 border-b dark:border-gray-700">
+                        <h3 className="text-xl font-semibold">
+                            {assignment?.id ? 'Edit' : 'Add'} Delivery Assignment
+                        </h3>
+                    </div>
+                    <fieldset className="p-6 space-y-4">
+                        <div>
+                            <label>Employee</label>
+                            <SearchableSelect
+                                options={employeeOptions}
+                                value={formData.employee || null}
+                                onChange={val => handleChange('employee', val)}
+                            />
+                        </div>
+                        <div>
+                            <label>Sale Invoice</label>
+                            <SearchableSelect
+                                options={saleOptions}
+                                value={formData.sale || null}
+                                onChange={val => handleChange('sale', val)}
+                            />
+                        </div>
+                        <div className="grid grid-cols-2 gap-4">
+                            <div>
+                                <label>Status</label>
+                                <SearchableSelect
+                                    options={statusOptions}
+                                    value={formData.status || 'ASSIGNED'}
+                                    onChange={val => handleChange('status', val)}
+                                />
+                            </div>
+                            <div>
+                                <label>Remarks</label>
+                                <input
+                                    name="remarks"
+                                    value={formData.remarks || ''}
+                                    onChange={handleInputChange}
+                                    className="mt-1 block w-full text-sm rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                                />
+                            </div>
+                        </div>
+                    </fieldset>
+                    <div className="p-4 bg-gray-50 dark:bg-gray-900 flex justify-end space-x-2">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="px-4 py-2 border rounded-md text-sm"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm"
+                        >
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+const DeliveryAssignments: React.FC = () => {
+    const [assignments, setAssignments] = useState<DeliveryAssignment[]>([]);
+    const [employees, setEmployees] = useState<Employee[]>([]);
+    const [sales, setSales] = useState<Order[]>([]);
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [editing, setEditing] = useState<Partial<DeliveryAssignment> | null>(null);
+
+    useEffect(() => {
+        Promise.all([getDeliveryAssignments(), getEmployees(), listSaleInvoices()])
+            .then(([a, e, s]) => {
+                setAssignments(a);
+                setEmployees(e);
+                setSales(s);
+            });
+    }, []);
+
+    const openModal = (assignment?: DeliveryAssignment) => {
+        setEditing(assignment || null);
+        setIsModalOpen(true);
+    };
+
+    const handleSave = async (data: Partial<DeliveryAssignment>) => {
+        const isEdit = !!data.id;
+        const saved = isEdit && data.id
+            ? await updateDeliveryAssignment(data.id, data)
+            : await createDeliveryAssignment(data);
+        setAssignments(prev => isEdit ? prev.map(a => a.id === saved.id ? saved : a) : [...prev, saved]);
+        setIsModalOpen(false);
+        setEditing(null);
+    };
+
+    const handleDelete = async (id: number) => {
+        await deleteDeliveryAssignment(id);
+        setAssignments(prev => prev.filter(a => a.id !== id));
+    };
+
+    const getSaleInfo = (saleId: number) => sales.find(s => s.id === saleId);
+    const getEmployeeName = (id: number) => employees.find(e => e.id === id)?.name || id;
+
+    return (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
+            <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+                <h3 className="text-lg font-semibold">Delivery Assignments</h3>
+                <button
+                    onClick={() => openModal()}
+                    className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md"
+                >
+                    New Assignment
+                </button>
+            </div>
+            <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                    <thead className="bg-gray-50 dark:bg-gray-700">
+                        <tr>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Invoice #</th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Customer</th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Delivery Person</th>
+                            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Status</th>
+                            <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 dark:divide-gray-600">
+                        {assignments.map(a => {
+                            const sale = getSaleInfo(a.sale);
+                            return (
+                                <tr key={a.id}>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{sale?.invoiceNo || a.sale}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{sale?.customer?.name || ''}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{getEmployeeName(a.employee)}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{a.status}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                        <button onClick={() => openModal(a)} className="text-blue-600 hover:text-blue-900">Edit</button>
+                                        <button onClick={() => handleDelete(a.id)} className="text-red-600 hover:text-red-900">Delete</button>
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                        {assignments.length === 0 && (
+                            <tr>
+                                <td colSpan={5} className="text-center py-12 text-gray-500">No delivery assignments found.</td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+            {isModalOpen && (
+                <AssignmentForm
+                    assignment={editing}
+                    employees={employees}
+                    sales={sales}
+                    onSave={handleSave}
+                    onClose={() => { setIsModalOpen(false); setEditing(null); }}
+                />
+            )}
+        </div>
+    );
+};
+
+export default DeliveryAssignments;
+

--- a/Frontend-PWD/components/Sidebar.tsx
+++ b/Frontend-PWD/components/Sidebar.tsx
@@ -101,6 +101,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isSidebarOpen, setSidebarOpen, curren
             <NavItem icon={ICONS.dashboard} label="Dashboard" to={ROUTES.dashboard.path} onClick={handleNavClick} />
             <NavHeader>Orders</NavHeader>
             <NavItem icon={ICONS.orders} label="Delivery Management" to={ROUTES['order-management'].path} onClick={handleNavClick} />
+            <NavItem icon={ICONS.list} label="Delivery Assignments" to={ROUTES['delivery-assignments'].path} onClick={handleNavClick} />
             <NavItem icon={ICONS.tasks} label="My Tasks" to={ROUTES.tasks.path} onClick={handleNavClick} />
             <NavItem icon={ICONS.leave} label="My Leave" to={ROUTES['my-leave'].path} onClick={handleNavClick} />
           </>

--- a/Frontend-PWD/routes.tsx
+++ b/Frontend-PWD/routes.tsx
@@ -29,6 +29,7 @@ export const ROUTES: Record<Page, RouteMeta> = {
   hr: { path: '/hr', title: 'HR Management' },
   crm: { path: '/crm', title: 'Customer Relationship Management' },
   tasks: { path: '/tasks', title: 'Task Management' },
+  'delivery-assignments': { path: '/delivery-assignments', title: 'Delivery Assignments' },
   management: { path: '/management', title: 'System Management' },
   expenses: { path: '/expenses', title: 'Expense Management' },
   'my-leave': { path: '/my-leave', title: 'My Leave Requests' },

--- a/Frontend-PWD/types.ts
+++ b/Frontend-PWD/types.ts
@@ -36,6 +36,7 @@ export type Page =
   | 'my-orders'
   | 'crm'
   | 'tasks'
+  | 'delivery-assignments'
   | 'recovery-officer-dashboard'
   | 'credit-recovery'
   | 'my-leave'
@@ -314,6 +315,15 @@ export interface Task {
     invoiceObjectId?: number | null;
     createdAt: string;
     updatedAt: string;
+}
+
+export interface DeliveryAssignment {
+    id: number;
+    employee: number;
+    sale: number;
+    assignedDate: string;
+    status: 'ASSIGNED' | 'DELIVERED' | 'FAILED';
+    remarks?: string | null;
 }
 
 // Inventory Module Types


### PR DESCRIPTION
## Summary
- add DeliveryAssignments page for CRUD operations and sale context
- expose delivery assignments route and sidebar link for delivery managers
- wire up DeliveryAssignments in app routing and types

## Testing
- `npm --prefix Frontend-PWD run build`


------
https://chatgpt.com/codex/tasks/task_e_6895e7df6318832996306508c2a4d0c9