### PR TITLE
Add leave balance management view

### DIFF
--- a/Frontend-PWD/App.tsx
+++ b/Frontend-PWD/App.tsx
@@ -31,6 +31,7 @@ import { NOTIFICATIONS } from './constants';
 import RecoveryOfficerDashboard from './components/RecoveryOfficerDashboard';
 import CreditRecovery from './components/CreditRecovery';
 import MyLeave from './components/MyLeave';
+import LeaveBalances from './components/LeaveBalances';
 import Ledger from './components/Ledger';
 import StockAudit from './components/StockAudit';
 import InvestorDashboard from './components/InvestorDashboard';
@@ -196,6 +197,7 @@ const App: React.FC = () => {
             <Route path={ROUTES.management.path} element={<Management />} />
             <Route path={ROUTES.expenses.path} element={<Expenses />} />
             <Route path={ROUTES['my-leave'].path} element={<MyLeave currentUser={currentUser} />} />
+            <Route path={ROUTES['leave-balances'].path} element={<LeaveBalances />} />
             <Route path={ROUTES.ledger.path} element={<Ledger currentUser={currentUser} />} />
             <Route path="*" element={<Navigate to={ROUTES.dashboard.path} />} />
           </Routes>

--- a/Frontend-PWD/components/HR.tsx
+++ b/Frontend-PWD/components/HR.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Employee, LeaveRequest, AttendanceRecord, EmployeeRole, LeaveStatus } from '../types';
+import ROUTES from '../routes';
 import { ICONS } from '../constants';
 import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
@@ -33,6 +35,7 @@ const TabButton: React.FC<{ active: boolean; onClick: () => void; children: Reac
 
 // Main HR Component
 const HR: React.FC = () => {
+    const navigate = useNavigate();
     const [activeTab, setActiveTab] = useState<HRTab>('employees');
 
     // Lifted state for all HR data
@@ -116,6 +119,7 @@ const HR: React.FC = () => {
                     <TabButton active={activeTab === 'employees'} onClick={() => setActiveTab('employees')}>Employees</TabButton>
                     <TabButton active={activeTab === 'leaves'} onClick={() => setActiveTab('leaves')}>Leave Requests</TabButton>
                     <TabButton active={activeTab === 'attendance'} onClick={() => setActiveTab('attendance')}>Attendance</TabButton>
+                    <TabButton active={false} onClick={() => navigate(ROUTES['leave-balances'].path)}>Leave Balances</TabButton>
                 </nav>
             </div>
             <div>{renderTabContent()}</div>

--- a/Frontend-PWD/components/LeaveBalances.tsx
+++ b/Frontend-PWD/components/LeaveBalances.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useState } from 'react';
+import { LeaveBalance, Employee } from '../types';
+import { getLeaveBalances, updateLeaveBalance, getEmployees } from '../services/hr';
+
+const LeaveBalances: React.FC = () => {
+  const [balances, setBalances] = useState<LeaveBalance[]>([]);
+  const [employees, setEmployees] = useState<Employee[]>([]);
+
+  useEffect(() => {
+    getLeaveBalances().then(setBalances);
+    getEmployees().then(setEmployees);
+  }, []);
+
+  const getEmployeeName = (id: number) => {
+    const emp = employees.find(e => e.id === id);
+    return emp ? emp.name : `Employee ${id}`;
+  };
+
+  const handleChange = (id: number, field: keyof LeaveBalance, value: number) => {
+    setBalances(prev => prev.map(b => (b.id === id ? { ...b, [field]: value } : b)));
+  };
+
+  const handleSave = async (balance: LeaveBalance) => {
+    const updated = await updateLeaveBalance(balance.id, {
+      annual: balance.annual,
+      sick: balance.sick,
+      casual: balance.casual,
+    });
+    setBalances(prev => prev.map(b => (b.id === updated.id ? updated : b)));
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
+      <div className="p-4 flex justify-between items-center border-b border-gray-200 dark:border-gray-700">
+        <h3 className="text-lg font-semibold">Leave Balances</h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Employee</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Annual</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Sick</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Casual</th>
+              <th className="px-6 py-3"></th>
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            {balances.map(b => (
+              <tr key={b.id}>
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{getEmployeeName(b.employee)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                  <input
+                    type="number"
+                    min="0"
+                    value={b.annual}
+                    onChange={e => handleChange(b.id, 'annual', parseInt(e.target.value) || 0)}
+                    className="w-20 px-2 py-1 border rounded-md bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600"
+                  />
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                  <input
+                    type="number"
+                    min="0"
+                    value={b.sick}
+                    onChange={e => handleChange(b.id, 'sick', parseInt(e.target.value) || 0)}
+                    className="w-20 px-2 py-1 border rounded-md bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600"
+                  />
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                  <input
+                    type="number"
+                    min="0"
+                    value={b.casual}
+                    onChange={e => handleChange(b.id, 'casual', parseInt(e.target.value) || 0)}
+                    className="w-20 px-2 py-1 border rounded-md bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white border-gray-300 dark:border-gray-600"
+                  />
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm">
+                  <button
+                    onClick={() => handleSave(b)}
+                    className="px-3 py-1 bg-blue-600 text-white rounded-md text-sm"
+                  >
+                    Save
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {balances.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-6 py-4 text-center text-sm text-gray-500">
+                  No leave balances found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default LeaveBalances;

--- a/Frontend-PWD/routes.tsx
+++ b/Frontend-PWD/routes.tsx
@@ -32,6 +32,7 @@ export const ROUTES: Record<Page, RouteMeta> = {
   management: { path: '/management', title: 'System Management' },
   expenses: { path: '/expenses', title: 'Expense Management' },
   'my-leave': { path: '/my-leave', title: 'My Leave Requests' },
+  'leave-balances': { path: '/leave-balances', title: 'Leave Balances' },
   ledger: { path: '/ledger', title: 'Customer Ledger' },
   login: { path: '/login', title: 'Login' },
   register: { path: '/register', title: 'Register' },

--- a/Frontend-PWD/types.ts
+++ b/Frontend-PWD/types.ts
@@ -39,6 +39,7 @@ export type Page =
   | 'recovery-officer-dashboard'
   | 'credit-recovery'
   | 'my-leave'
+  | 'leave-balances'
   | 'ledger'
   | 'stock-audit'
   | 'investors'


### PR DESCRIPTION
## Summary
- display and edit leave quotas for each employee
- add `leave-balances` route and integrate navigation from HR module

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_6895e7e1c08c832984ffa3245467b3a7