### PR TITLE
Create leave balance on employee creation

### DIFF
--- a/hr/apps.py
+++ b/hr/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class HrConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'hr'
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/hr/signals.py
+++ b/hr/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Employee, LeaveBalance
+
+
+@receiver(post_save, sender=Employee)
+def create_leave_balance(sender, instance, created, **kwargs):
+    """Create a LeaveBalance record for each new Employee."""
+    if created:
+        LeaveBalance.objects.create(employee=instance)


### PR DESCRIPTION
## Summary
- add post_save signal to create LeaveBalance for new employees
- load hr signals on app startup

## Testing
- `python manage.py test` *(fails: table inventory_product has no column named company_id)*

------
https://chatgpt.com/codex/tasks/task_e_6895e7e38e38832984c77b5d52a2ec86