### PR TITLE
Add management API endpoints for settings

### DIFF
--- a/erp/urls.py
+++ b/erp/urls.py
@@ -38,8 +38,8 @@ urlpatterns = [
     path('api/sync/', include('syncqueue.urls')),
 
     path('api/hr/', include('hr.urls')),
-
     path('api/user/', include('user.urls')),
+    path('api/management/', include('setting.urls')),
 
 
 

--- a/setting/serializers.py
+++ b/setting/serializers.py
@@ -1,0 +1,45 @@
+from rest_framework import serializers
+
+from .models import City, Area, Company, Group, Distributor, Branch, Warehouse
+
+
+class CitySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = City
+        fields = "__all__"
+
+
+class AreaSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Area
+        fields = "__all__"
+
+
+class CompanySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Company
+        fields = "__all__"
+
+
+class GroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Group
+        fields = "__all__"
+
+
+class DistributorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Distributor
+        fields = "__all__"
+
+
+class BranchSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Branch
+        fields = "__all__"
+
+
+class WarehouseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Warehouse
+        fields = "__all__"

--- a/setting/urls.py
+++ b/setting/urls.py
@@ -1,0 +1,26 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .views import (
+    CityViewSet,
+    AreaViewSet,
+    CompanyViewSet,
+    GroupViewSet,
+    DistributorViewSet,
+    BranchViewSet,
+    WarehouseViewSet,
+)
+
+
+router = DefaultRouter()
+router.register(r'cities', CityViewSet)
+router.register(r'areas', AreaViewSet)
+router.register(r'companies', CompanyViewSet)
+router.register(r'groups', GroupViewSet)
+router.register(r'distributors', DistributorViewSet)
+router.register(r'branches', BranchViewSet)
+router.register(r'warehouses', WarehouseViewSet)
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/setting/views.py
+++ b/setting/views.py
@@ -1,3 +1,54 @@
-from django.shortcuts import render
+from rest_framework import permissions, viewsets
 
-# Create your views here.
+from .models import City, Area, Company, Group, Distributor, Branch, Warehouse
+from .serializers import (
+    CitySerializer,
+    AreaSerializer,
+    CompanySerializer,
+    GroupSerializer,
+    DistributorSerializer,
+    BranchSerializer,
+    WarehouseSerializer,
+)
+
+
+class CityViewSet(viewsets.ModelViewSet):
+    queryset = City.objects.all()
+    serializer_class = CitySerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class AreaViewSet(viewsets.ModelViewSet):
+    queryset = Area.objects.all()
+    serializer_class = AreaSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class CompanyViewSet(viewsets.ModelViewSet):
+    queryset = Company.objects.all()
+    serializer_class = CompanySerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class GroupViewSet(viewsets.ModelViewSet):
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class DistributorViewSet(viewsets.ModelViewSet):
+    queryset = Distributor.objects.all()
+    serializer_class = DistributorSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class BranchViewSet(viewsets.ModelViewSet):
+    queryset = Branch.objects.all()
+    serializer_class = BranchSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class WarehouseViewSet(viewsets.ModelViewSet):
+    queryset = Warehouse.objects.all()
+    serializer_class = WarehouseSerializer
+    permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary
- add serializers for City, Area, Company, Group, Distributor, Branch, and Warehouse
- expose DRF viewsets for each setting model
- wire management routes under `/api/management/`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'unfold')*

------
https://chatgpt.com/codex/tasks/task_e_6895fa5ca2d08329bda901ef5716eda0