### PR TITLE
Load invoice and return dropdowns from API

### DIFF
--- a/Frontend-PWD/components/PurchaseInvoice.tsx
+++ b/Frontend-PWD/components/PurchaseInvoice.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { PurchaseInvoice, PurchaseInvoiceItem, Task, InvoiceStatus } from '../types';
-import { SUPPLIERS, PRODUCTS, EMPLOYEES, PARTIES_DATA } from '../constants';
-import { ICONS } from '../constants';
+import { PurchaseInvoice, PurchaseInvoiceItem, Task, InvoiceStatus, Product, Party } from '../types';
+import { EMPLOYEES, ICONS } from '../constants';
+import { fetchProducts, fetchParties } from '../services/inventory';
 import SearchableSelect from './SearchableSelect';
 import { createPurchaseInvoice, updatePurchaseInvoice } from '../services/purchase';
 
@@ -43,6 +43,8 @@ const PurchaseInvoiceForm: React.FC<PurchaseInvoiceProps> = ({ invoiceToEdit, ha
     investorId: undefined,
   });
   const [supplierId, setSupplierId] = useState<number | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [parties, setParties] = useState<Party[]>([]);
   
   const [createTask, setCreateTask] = useState(false);
   const [taskDetails, setTaskDetails] = useState<Partial<Task>>({
@@ -61,8 +63,13 @@ const PurchaseInvoiceForm: React.FC<PurchaseInvoiceProps> = ({ invoiceToEdit, ha
     }
   }, [invoiceToEdit, isEditMode]);
 
-  const investorList = PARTIES_DATA.filter(p => p.partyType === 'investor');
-  const supplier = useMemo(() => SUPPLIERS.find(s => s.id === supplierId), [supplierId]);
+  useEffect(() => {
+    fetchProducts().then(setProducts).catch(() => setProducts([]));
+    fetchParties().then(setParties).catch(() => setParties([]));
+  }, []);
+  const investors = useMemo(() => parties.filter(p => p.partyType === 'investor'), [parties]);
+  const suppliers = useMemo(() => parties.filter(p => p.partyType === 'supplier'), [parties]);
+  const supplier = useMemo(() => suppliers.find(s => s.id === supplierId), [supplierId, suppliers]);
 
   useEffect(() => {
     const totalAmount = invoice.items.reduce((acc, item) => acc + item.netAmount, 0);
@@ -163,11 +170,11 @@ const PurchaseInvoiceForm: React.FC<PurchaseInvoiceProps> = ({ invoiceToEdit, ha
       <fieldset className="p-4 border dark:border-gray-700 rounded-md">
         <legend className="px-2 text-lg font-semibold">Purchase Header</legend>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <FormField label="Supplier"><SearchableSelect options={SUPPLIERS.map(s => ({ value: s.id, label: s.name }))} value={supplierId} onChange={val => setSupplierId(val as number)} /></FormField>
+            <FormField label="Supplier"><SearchableSelect options={suppliers.map(s => ({ value: s.id, label: s.name }))} value={supplierId} onChange={val => setSupplierId(val as number)} /></FormField>
             <FormField label="Invoice Date"><FormInput type="date" id="date" value={invoice.date} onChange={(e) => setInvoice(prev => ({ ...prev, date: e.target.value }))} /></FormField>
             <FormField label="Company Inv. #"><FormInput type="text" id="companyInvoiceNumber" placeholder="Supplier invoice number" value={invoice.companyInvoiceNumber} onChange={(e) => setInvoice(prev => ({ ...prev, companyInvoiceNumber: e.target.value }))}/></FormField>
             <FormField label="Payment Method"><FormSelect value={invoice.paymentMethod} onChange={(e) => { const newMethod = e.target.value as 'Cash' | 'Credit'; setInvoice(prev => ({...prev, paymentMethod: newMethod, paidAmount: newMethod === 'Credit' ? 0 : prev.grandTotal})); }}><option value="Credit">Credit Purchase</option><option value="Cash">Cash Purchase</option></FormSelect></FormField>
-            <FormField label="Investor (Optional)"><SearchableSelect options={investorList.map(i => ({ value: i.id, label: i.name }))} value={invoice.investorId || null} onChange={val => setInvoice(prev => ({ ...prev, investorId: val ? Number(val) : undefined }))}/></FormField>
+            <FormField label="Investor (Optional)"><SearchableSelect options={investors.map(i => ({ value: i.id, label: i.name }))} value={invoice.investorId || null} onChange={val => setInvoice(prev => ({ ...prev, investorId: val ? Number(val) : undefined }))}/></FormField>
         </div>
       </fieldset>
 
@@ -191,7 +198,7 @@ const PurchaseInvoiceForm: React.FC<PurchaseInvoiceProps> = ({ invoiceToEdit, ha
                 <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-600">
                     {invoice.items.map(item => (
                     <tr key={item.id}>
-                        <td className="p-1" style={{minWidth: '200px'}}><SearchableSelect options={PRODUCTS.map(p => ({ value: p.id, label: p.name }))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
+                        <td className="p-1" style={{minWidth: '200px'}}><SearchableSelect options={products.map(p => ({ value: p.id, label: p.name }))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
                         <td className="p-1"><FormInput type="text" placeholder="Batch No." value={item.batchNo} onChange={(e) => handleItemChange(item.id, 'batchNo', e.target.value)} style={{minWidth: '110px'}}/></td>
                         <td className="p-1"><FormInput type="date" value={item.expiryDate} onChange={(e) => handleItemChange(item.id, 'expiryDate', e.target.value)} style={{minWidth: '140px'}}/></td>
                         <td className="p-1"><FormInput type="number" value={item.quantity} onChange={(e) => handleItemChange(item.id, 'quantity', parseInt(e.target.value))} min="1" style={{width: '80px'}}/></td>

--- a/Frontend-PWD/components/PurchaseReturn.tsx
+++ b/Frontend-PWD/components/PurchaseReturn.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { PurchaseReturn, PurchaseReturnItem } from '../types';
-import { SUPPLIERS, PRODUCTS, ICONS } from '../constants';
+import { PurchaseReturn, PurchaseReturnItem, Product, Party } from '../types';
+import { ICONS } from '../constants';
 import SearchableSelect from './SearchableSelect';
 import { createPurchaseReturn, updatePurchaseReturn } from '../services/purchase';
+import { fetchProducts, fetchParties } from '../services/inventory';
 
 interface PurchaseReturnProps {
   returnToEdit: PurchaseReturn | null;
@@ -21,6 +22,10 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
     totalAmount: 0,
   });
   const [supplierId, setSupplierId] = useState<number | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [parties, setParties] = useState<Party[]>([]);
+  const suppliers = useMemo(() => parties.filter(p => p.partyType === 'supplier'), [parties]);
+  const supplier = useMemo(() => suppliers.find(s => s.id === supplierId), [supplierId, suppliers]);
 
   const isEditMode = useMemo(() => !!returnToEdit, [returnToEdit]);
 
@@ -31,6 +36,11 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
       setSupplierId(supplier?.id || null);
     }
   }, [returnToEdit, isEditMode]);
+
+  useEffect(() => {
+    fetchProducts().then(setProducts).catch(() => setProducts([]));
+    fetchParties().then(setParties).catch(() => setParties([]));
+  }, []);
 
   useEffect(() => {
     const totalAmount = pReturn.items.reduce((acc, item) => acc + item.amount, 0);
@@ -60,7 +70,7 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
       if (item.id === id) {
         const updatedItem = { ...item, [field]: value };
         if (field === 'productId') {
-          const product = PRODUCTS.find(p => p.id === Number(value));
+          const product = products.find(p => p.id === Number(value));
           updatedItem.purchasePrice = product ? product.tradePrice : 0;
         }
         updatedItem.amount = updatedItem.quantity * updatedItem.purchasePrice;
@@ -75,7 +85,7 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
     const finalReturn: PurchaseReturn = {
       id: isEditMode ? returnToEdit!.id : new Date().getTime().toString(),
       ...pReturn,
-      supplier: SUPPLIERS.find(s => s.id === supplierId) || null,
+      supplier: supplier || null,
     };
 
     if (isEditMode) {
@@ -91,7 +101,7 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
       <fieldset className="p-4 border dark:border-gray-700 rounded-md">
         <legend className="px-2 text-lg font-semibold">Return Details</legend>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div><label className="block text-sm font-medium mb-1">Supplier</label><SearchableSelect options={SUPPLIERS.map(s => ({value: s.id, label: s.name}))} value={supplierId} onChange={val => setSupplierId(val as number)} /></div>
+          <div><label className="block text-sm font-medium mb-1">Supplier</label><SearchableSelect options={suppliers.map(s => ({value: s.id, label: s.name}))} value={supplierId} onChange={val => setSupplierId(val as number)} /></div>
           <div><label className="block text-sm font-medium mb-1">Return Date</label><FormInput type="date" value={pReturn.date} onChange={(e) => setPReturn(prev => ({ ...prev, date: e.target.value }))} /></div>
           <div><label className="block text-sm font-medium mb-1">Return #</label><FormInput type="text" readOnly value={pReturn.returnNo} className="bg-gray-100 dark:bg-gray-700" /></div>
         </div>
@@ -114,7 +124,7 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
             <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-600">
               {pReturn.items.map(item => (
                 <tr key={item.id}>
-                  <td className="p-1" style={{minWidth: '250px'}}><SearchableSelect options={PRODUCTS.map(p => ({value: p.id, label: p.name}))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
+                  <td className="p-1" style={{minWidth: '250px'}}><SearchableSelect options={products.map(p => ({value: p.id, label: p.name}))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
                   <td className="p-1"><FormInput type="text" placeholder="Batch No." value={item.batchNo} onChange={(e) => handleItemChange(item.id, 'batchNo', e.target.value)} style={{minWidth: '120px'}} /></td>
                   <td className="p-1"><FormInput type="number" value={item.quantity} onChange={(e) => handleItemChange(item.id, 'quantity', parseInt(e.target.value))} min="1" style={{width: '100px'}} /></td>
                   <td className="p-1"><FormInput type="number" value={item.purchasePrice} onChange={(e) => handleItemChange(item.id, 'purchasePrice', parseFloat(e.target.value))} min="0" step="0.01" style={{width: '120px'}}/></td>

--- a/Frontend-PWD/components/SaleInvoice.tsx
+++ b/Frontend-PWD/components/SaleInvoice.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Order, InvoiceItem, Party, Area, PriceListItem, Task } from '../types';
-import { PRODUCTS, BATCHES, ICONS, CITIES, AREAS, EMPLOYEES, COMPANIES, PARTIES_DATA, PRICE_LISTS, PRICE_LIST_ITEMS } from '../constants';
+import { Order, InvoiceItem, Party, Area, PriceListItem, Task, Product, City } from '../types';
+import { BATCHES, ICONS, EMPLOYEES, COMPANIES, PRICE_LISTS, PRICE_LIST_ITEMS } from '../constants';
+import { fetchProducts, fetchParties } from '../services/inventory';
+import { fetchCities, fetchAreas } from '../services/settings';
 import SearchableSelect from './SearchableSelect';
 import { addToSyncQueue, registerSync } from '../services/db';
 
@@ -48,6 +50,10 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
     paidAmount: 0,
   });
   const [customerId, setCustomerId] = useState<number | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [parties, setParties] = useState<Party[]>([]);
+  const [cities, setCities] = useState<City[]>([]);
+  const [areas, setAreas] = useState<Area[]>([]);
   
   const [selectedCustomerDetails, setSelectedCustomerDetails] = useState<{ creditLimit: number, currentBalance: number, priceListId: number | null, priceListItems: PriceListItem[] } | null>(null);
   const [createTask, setCreateTask] = useState(false);
@@ -66,17 +72,31 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
     }
   }, [invoiceToEdit, isEditMode]);
 
+  useEffect(() => {
+    fetchProducts().then(setProducts).catch(() => setProducts([]));
+    fetchParties().then(setParties).catch(() => setParties([]));
+    Promise.all([fetchCities(), fetchAreas()])
+      .then(([c, a]) => {
+        setCities(c);
+        setAreas(a);
+      })
+      .catch(() => {
+        setCities([]);
+        setAreas([]);
+      });
+  }, []);
+
 
   // Derived state for filtered dropdowns
   const filteredAreas = useMemo(() => {
     if (!invoice.cityId) return [];
-    return AREAS.filter(a => a.cityId === invoice.cityId);
-  }, [invoice.cityId]);
+    return areas.filter(a => a.cityId === invoice.cityId);
+  }, [invoice.cityId, areas]);
 
   const filteredCustomers = useMemo(() => {
     if (!invoice.cityId || !invoice.areaId) return [];
-    return PARTIES_DATA.filter(p => p.partyType === 'customer' && p.cityId === invoice.cityId && p.areaId === invoice.areaId);
-  }, [invoice.cityId, invoice.areaId]);
+    return parties.filter(p => p.partyType === 'customer' && p.cityId === invoice.cityId && p.areaId === invoice.areaId);
+  }, [invoice.cityId, invoice.areaId, parties]);
 
   // Effect to calculate totals
   useEffect(() => {
@@ -109,7 +129,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
     return null;
   }, [invoice.grandTotal, selectedCustomerDetails, invoice.paymentMethod]);
   
-  const customer = useMemo(() => PARTIES_DATA.find(p => p.id === customerId), [customerId]);
+  const customer = useMemo(() => parties.find(p => p.id === customerId), [customerId, parties]);
 
   useEffect(() => {
       if (customer) {
@@ -117,8 +137,8 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
       }
   }, [customer, invoice.invoiceNo]);
 
-   useEffect(() => {
-      const customerParty = PARTIES_DATA.find(p => p.id === customerId && p.partyType === 'customer');
+  useEffect(() => {
+      const customerParty = parties.find(p => p.id === customerId && p.partyType === 'customer');
       if (customerParty) {
           const priceListId = customerParty.priceListId || null;
           setSelectedCustomerDetails({
@@ -132,7 +152,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
               ...prev,
               items: prev.items.map(item => {
                   if(!item.productId) return item;
-                  const product = PRODUCTS.find(p => p.id === item.productId);
+                  const product = products.find(p => p.id === item.productId);
                   if (!product) return item;
                   const customPriceItem = priceListId ? PRICE_LIST_ITEMS.find(pli => pli.priceListId === priceListId && pli.productId === product.id) : undefined;
                   const rate = customPriceItem ? customPriceItem.customPrice : product.retailPrice;
@@ -148,7 +168,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
       } else {
           setSelectedCustomerDetails(null);
       }
-  }, [customerId]);
+  }, [customerId, parties, products]);
 
   const handleHeaderChange = (field: keyof typeof invoice, value: any) => {
     setInvoice(prev => {
@@ -192,7 +212,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
     const newItems = invoice.items.map(item => {
       if (item.id === id) {
         const updatedItem = { ...item, [field]: value };
-        const product = PRODUCTS.find(p => p.id === updatedItem.productId);
+        const product = products.find(p => p.id === updatedItem.productId);
 
         if (field === 'productId' || field === 'batchId') {
             updatedItem.batchId = field === 'productId' ? null : updatedItem.batchId;
@@ -230,7 +250,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
 
     const finalInvoice: Order = {
         ...invoice,
-        customer: PARTIES_DATA.find(p => p.id === customerId) || null,
+        customer: parties.find(p => p.id === customerId) || null,
         userId: customerId,
     };
 
@@ -269,7 +289,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
       <fieldset className="border dark:border-gray-700 p-4 rounded-md">
         <legend className="px-2 text-lg font-semibold">Invoice Header</legend>
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-            <FormField label="City"><SearchableSelect options={CITIES.map(c => ({ value: c.id, label: c.name }))} value={invoice.cityId} onChange={val => handleHeaderChange('cityId', val)} /></FormField>
+            <FormField label="City"><SearchableSelect options={cities.map(c => ({ value: c.id, label: c.name }))} value={invoice.cityId} onChange={val => handleHeaderChange('cityId', val)} /></FormField>
             <FormField label="Area"><SearchableSelect options={filteredAreas.map(a => ({ value: a.id, label: a.name }))} value={invoice.areaId} onChange={val => handleHeaderChange('areaId', val)} disabled={!invoice.cityId} /></FormField>
             <FormField label="Client"><SearchableSelect options={filteredCustomers.map(c => ({ value: c.id, label: c.name }))} value={customerId} onChange={val => setCustomerId(val as number)} disabled={!invoice.areaId} /></FormField>
             <FormField label="Supplying Man"><SearchableSelect options={EMPLOYEES.filter(e => e.role === 'SALES' || e.role === 'DELIVERY').map(e => ({ value: e.id, label: e.name }))} value={invoice.supplyingManId} onChange={val => handleHeaderChange('supplyingManId', val)} /></FormField>
@@ -310,7 +330,7 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
                         const selectedBatch = BATCHES.find(b => b.id === item.batchId);
                         return (
                             <tr key={item.id}>
-                                <td className="p-1" style={{minWidth: '200px'}}><SearchableSelect options={PRODUCTS.map(p => ({ value: p.id, label: p.name }))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
+                                <td className="p-1" style={{minWidth: '200px'}}><SearchableSelect options={products.map(p => ({ value: p.id, label: p.name }))} value={item.productId} onChange={val => handleItemChange(item.id, 'productId', val)} /></td>
                                 <td className="p-1" style={{minWidth: '150px'}}><SearchableSelect options={(availableBatches.get(item.productId || 0) || []).map(b => ({ value: b.id, label: b.batchNo }))} value={item.batchId} onChange={val => handleItemChange(item.id, 'batchId', val)} disabled={!item.productId} /></td>
                                 <td className="p-1 text-sm text-gray-500 dark:text-gray-400" style={{minWidth: '110px'}}>{selectedBatch?.expiryDate || '-'}</td>
                                 <td className="p-1 text-sm text-gray-500 dark:text-gray-400">{selectedBatch?.stock || '-'}</td>

--- a/Frontend-PWD/services/inventory.ts
+++ b/Frontend-PWD/services/inventory.ts
@@ -1,0 +1,14 @@
+import { Product, Party } from '../types';
+
+const API_BASE = 'http://127.0.0.1:8000/inventory';
+
+async function request<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+
+export const fetchProducts = () => request<Product[]>(`${API_BASE}/products/`);
+export const fetchParties = () => request<Party[]>(`${API_BASE}/parties/`);

--- a/Frontend-PWD/services/settings.ts
+++ b/Frontend-PWD/services/settings.ts
@@ -1,0 +1,14 @@
+import { City, Area } from '../types';
+
+const API_BASE = 'http://127.0.0.1:8000/settings';
+
+async function request<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+
+export const fetchCities = () => request<City[]>(`${API_BASE}/cities/`);
+export const fetchAreas = () => request<Area[]>(`${API_BASE}/areas/`);


### PR DESCRIPTION
## Summary
- add inventory and settings service modules to fetch products, parties, cities, and areas
- refactor sale/purchase invoice and return forms to load dropdown options from backend data and filter customers by city/area

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6895fa5f78d883299a9cd18da5d8d657