### PR TITLE
Add invoice lookup for returns

### DIFF
--- a/Frontend-PWD/components/PurchaseReturn.tsx
+++ b/Frontend-PWD/components/PurchaseReturn.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { PurchaseReturn, PurchaseReturnItem } from '../types';
+import { PurchaseReturn, PurchaseReturnItem, PurchaseInvoice } from '../types';
 import { SUPPLIERS, PRODUCTS, ICONS } from '../constants';
 import SearchableSelect from './SearchableSelect';
-import { createPurchaseReturn, updatePurchaseReturn } from '../services/purchase';
+import { createPurchaseReturn, updatePurchaseReturn, fetchPurchaseInvoices, fetchPurchaseInvoiceByNumber } from '../services/purchase';
 
 interface PurchaseReturnProps {
   returnToEdit: PurchaseReturn | null;
@@ -21,6 +21,9 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
     totalAmount: 0,
   });
   const [supplierId, setSupplierId] = useState<number | null>(null);
+  const [invoices, setInvoices] = useState<PurchaseInvoice[]>([]);
+  const [selectedInvoiceNo, setSelectedInvoiceNo] = useState<string | null>(null);
+  const [invoiceItems, setInvoiceItems] = useState<{productId: number; batchNo: string; quantity: number;}[]>([]);
 
   const isEditMode = useMemo(() => !!returnToEdit, [returnToEdit]);
 
@@ -33,9 +36,47 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
   }, [returnToEdit, isEditMode]);
 
   useEffect(() => {
+    fetchPurchaseInvoices().then(setInvoices).catch(() => {});
+  }, []);
+
+  useEffect(() => {
     const totalAmount = pReturn.items.reduce((acc, item) => acc + item.amount, 0);
     setPReturn(prev => ({ ...prev, totalAmount }));
   }, [pReturn.items]);
+
+  const handleInvoiceSelect = async (val: string | number | null) => {
+    const invoiceNo = val ? String(val) : null;
+    setSelectedInvoiceNo(invoiceNo);
+    if (invoiceNo) {
+      try {
+        const inv = await fetchPurchaseInvoiceByNumber(invoiceNo);
+        setSupplierId(inv.supplier as unknown as number);
+        setPReturn(prev => ({
+          ...prev,
+          warehouseId: inv.warehouse as unknown as number,
+          items: inv.items.map((it: any) => ({
+            id: String(it.id),
+            productId: it.product,
+            batchNo: String(it.batch_number),
+            expiryDate: it.expiry_date,
+            quantity: it.quantity,
+            purchasePrice: Number(it.purchase_price),
+            salePrice: Number(it.sale_price),
+            amount: Number(it.amount),
+          })),
+        }));
+        setInvoiceItems(inv.items.map((it: any) => ({
+          productId: it.product,
+          batchNo: String(it.batch_number),
+          quantity: it.quantity,
+        })));
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
+      setInvoiceItems([]);
+    }
+  };
 
   const handleAddItem = () => {
     const newItem: PurchaseReturnItem = {
@@ -71,7 +112,26 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
     setPReturn(prev => ({ ...prev, items: newItems }));
   };
 
+  const validateItems = () => {
+    if (!selectedInvoiceNo) return true;
+    for (const item of pReturn.items) {
+      const match = invoiceItems.find(
+        inv => inv.productId === item.productId && inv.batchNo === String(item.batchNo)
+      );
+      if (!match) {
+        alert('Return item not in original invoice');
+        return false;
+      }
+      if (item.quantity > match.quantity) {
+        alert('Return quantity exceeds purchased quantity');
+        return false;
+      }
+    }
+    return true;
+  };
+
   const handleSubmit = async () => {
+    if (!validateItems()) return;
     const finalReturn: PurchaseReturn = {
       id: isEditMode ? returnToEdit!.id : new Date().getTime().toString(),
       ...pReturn,
@@ -90,8 +150,9 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 md:p-8 space-y-6">
       <fieldset className="p-4 border dark:border-gray-700 rounded-md">
         <legend className="px-2 text-lg font-semibold">Return Details</legend>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div><label className="block text-sm font-medium mb-1">Supplier</label><SearchableSelect options={SUPPLIERS.map(s => ({value: s.id, label: s.name}))} value={supplierId} onChange={val => setSupplierId(val as number)} /></div>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+          <div><label className="block text-sm font-medium mb-1">Invoice No</label><SearchableSelect options={invoices.map(inv => ({value: inv.invoiceNo, label: inv.invoiceNo}))} value={selectedInvoiceNo} onChange={handleInvoiceSelect} placeholder="Select Invoice" /></div>
+          <div><label className="block text-sm font-medium mb-1">Supplier</label><SearchableSelect options={SUPPLIERS.map(s => ({value: s.id, label: s.name}))} value={supplierId} onChange={val => setSupplierId(val as number)} disabled={!!selectedInvoiceNo} /></div>
           <div><label className="block text-sm font-medium mb-1">Return Date</label><FormInput type="date" value={pReturn.date} onChange={(e) => setPReturn(prev => ({ ...prev, date: e.target.value }))} /></div>
           <div><label className="block text-sm font-medium mb-1">Return #</label><FormInput type="text" readOnly value={pReturn.returnNo} className="bg-gray-100 dark:bg-gray-700" /></div>
         </div>

--- a/Frontend-PWD/components/SaleReturn.tsx
+++ b/Frontend-PWD/components/SaleReturn.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { SaleReturn, SaleReturnItem } from '../types';
+import { SaleReturn, SaleReturnItem, Order } from '../types';
 import { PARTIES_DATA, PRODUCTS, ICONS } from '../constants';
 import SearchableSelect from './SearchableSelect';
-import { createSaleReturn } from '../services/sale';
+import { createSaleReturn, listSaleInvoices, fetchSaleInvoiceByNumber } from '../services/sale';
 
 interface SaleReturnProps {
   returnToEdit: SaleReturn | null;
@@ -22,6 +22,9 @@ const SaleReturnForm: React.FC<SaleReturnProps> = ({ returnToEdit, handleClose }
     totalAmount: 0,
   });
   const [customerId, setCustomerId] = useState<number | null>(null);
+  const [invoices, setInvoices] = useState<Order[]>([]);
+  const [selectedInvoiceNo, setSelectedInvoiceNo] = useState<string | null>(null);
+  const [invoiceItems, setInvoiceItems] = useState<{productId: number; batchNo: string; quantity: number;}[]>([]);
 
   const isEditMode = useMemo(() => !!returnToEdit, [returnToEdit]);
 
@@ -34,9 +37,49 @@ const SaleReturnForm: React.FC<SaleReturnProps> = ({ returnToEdit, handleClose }
   }, [returnToEdit, isEditMode]);
 
   useEffect(() => {
+    listSaleInvoices().then(setInvoices).catch(() => {});
+  }, []);
+
+  useEffect(() => {
     const totalAmount = sReturn.items.reduce((acc, item) => acc + item.amount, 0);
     setSReturn(prev => ({ ...prev, totalAmount }));
   }, [sReturn.items]);
+
+  const handleInvoiceSelect = async (val: string | number | null) => {
+    const invoiceNo = val ? String(val) : null;
+    setSelectedInvoiceNo(invoiceNo);
+    if (invoiceNo) {
+      try {
+        const inv = await fetchSaleInvoiceByNumber(invoiceNo);
+        setCustomerId(inv.customer as unknown as number);
+        setSReturn(prev => ({
+          ...prev,
+          warehouseId: inv.warehouse as unknown as number,
+          items: inv.items.map((it: any) => ({
+            id: String(it.id),
+            productId: it.product,
+            batchNo: String(it.batch),
+            expiryDate: '',
+            quantity: it.quantity,
+            rate: Number(it.rate),
+            discount1: Number(it.discount1),
+            discount2: Number(it.discount2),
+            amount: Number(it.amount),
+            netAmount: Number(it.net_amount),
+          })),
+        }));
+        setInvoiceItems(inv.items.map((it: any) => ({
+          productId: it.product,
+          batchNo: String(it.batch),
+          quantity: it.quantity,
+        })));
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
+      setInvoiceItems([]);
+    }
+  };
 
   const handleAddItem = () => {
     const newItem: SaleReturnItem = { id: Date.now().toString(), productId: null, batchNo: '', expiryDate: '', quantity: 1, rate: 0, discount1: 0, discount2: 0, amount: 0, netAmount: 0 };
@@ -62,7 +105,26 @@ const SaleReturnForm: React.FC<SaleReturnProps> = ({ returnToEdit, handleClose }
     setSReturn(prev => ({ ...prev, items: newItems }));
   };
   
+  const validateItems = () => {
+    if (!selectedInvoiceNo) return true;
+    for (const item of sReturn.items) {
+      const match = invoiceItems.find(
+        inv => inv.productId === item.productId && inv.batchNo === String(item.batchNo)
+      );
+      if (!match) {
+        alert('Return item not in original invoice');
+        return false;
+      }
+      if (item.quantity > match.quantity) {
+        alert('Return quantity exceeds sold quantity');
+        return false;
+      }
+    }
+    return true;
+  };
+
   const handleSubmit = async () => {
+    if (!validateItems()) return;
     const finalReturn: SaleReturn = {
         id: isEditMode ? returnToEdit.id : new Date().getTime().toString(),
         ...sReturn,
@@ -77,8 +139,9 @@ const SaleReturnForm: React.FC<SaleReturnProps> = ({ returnToEdit, handleClose }
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 md:p-8 space-y-6">
         <fieldset className="p-4 border dark:border-gray-700 rounded-md">
             <legend className="px-2 text-lg font-semibold">Return Details</legend>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div><label className="block text-sm font-medium mb-1">Customer</label><SearchableSelect options={PARTIES_DATA.filter(p => p.partyType === 'customer').map(c=>({value: c.id, label:c.name}))} value={customerId} onChange={val => setCustomerId(val as number)} /></div>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+                <div><label className="block text-sm font-medium mb-1">Invoice No</label><SearchableSelect options={invoices.map(inv => ({value: inv.invoiceNo, label: inv.invoiceNo}))} value={selectedInvoiceNo} onChange={handleInvoiceSelect} placeholder="Select Invoice" /></div>
+                <div><label className="block text-sm font-medium mb-1">Customer</label><SearchableSelect options={PARTIES_DATA.filter(p => p.partyType === 'customer').map(c=>({value: c.id, label:c.name}))} value={customerId} onChange={val => setCustomerId(val as number)} disabled={!!selectedInvoiceNo} /></div>
                 <div><label className="block text-sm font-medium mb-1">Return Date</label><FormInput type="date" value={sReturn.date} onChange={(e) => setSReturn(prev => ({ ...prev, date: e.target.value }))} /></div>
                 <div><label className="block text-sm font-medium mb-1">Return #</label><FormInput type="text" readOnly value={sReturn.returnNo} className="bg-gray-100 dark:bg-gray-700" /></div>
             </div>

--- a/Frontend-PWD/services/purchase.ts
+++ b/Frontend-PWD/services/purchase.ts
@@ -15,6 +15,8 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
 
 // Purchase Invoices
 export const fetchPurchaseInvoices = () => request<PurchaseInvoice[]>(`${API_BASE}/invoices/`);
+export const fetchPurchaseInvoiceByNumber = (invoiceNo: string) =>
+  request<PurchaseInvoice>(`${API_BASE}/invoices/by-number/${invoiceNo}/`);
 export const createPurchaseInvoice = (data: Partial<PurchaseInvoice>) =>
   request<PurchaseInvoice>(`${API_BASE}/invoices/`, { method: 'POST', body: JSON.stringify(data) });
 export const updatePurchaseInvoice = (id: number | string, data: Partial<PurchaseInvoice>) =>

--- a/Frontend-PWD/services/sale.ts
+++ b/Frontend-PWD/services/sale.ts
@@ -8,6 +8,12 @@ export async function listSaleInvoices(): Promise<Order[]> {
     return res.json();
 }
 
+export async function fetchSaleInvoiceByNumber(invoiceNo: string): Promise<Order> {
+    const res = await fetch(`${API_BASE}/invoices/by-number/${invoiceNo}/`);
+    if (!res.ok) throw new Error('Failed to fetch sale invoice');
+    return res.json();
+}
+
 export async function createSaleInvoice(invoice: Partial<Order>): Promise<Order> {
     const payload = {
         invoice_no: invoice.invoiceNo,

--- a/purchase/views.py
+++ b/purchase/views.py
@@ -1,4 +1,7 @@
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from django.shortcuts import get_object_or_404
 
 from .models import PurchaseInvoice, PurchaseReturn, InvestorTransaction
 from .serializers import (
@@ -11,6 +14,16 @@ from .serializers import (
 class PurchaseInvoiceViewSet(viewsets.ModelViewSet):
     queryset = PurchaseInvoice.objects.all()
     serializer_class = PurchaseInvoiceSerializer
+
+    @action(detail=False, methods=["get"], url_path="by-number/(?P<invoice_no>[^/.]+)")
+    def retrieve_by_number(self, request, invoice_no=None):
+        """Retrieve a purchase invoice using its invoice_no."""
+        invoice = get_object_or_404(
+            PurchaseInvoice.objects.all().prefetch_related("items"),
+            invoice_no=invoice_no,
+        )
+        serializer = self.get_serializer(invoice)
+        return Response(serializer.data)
 
 
 class PurchaseReturnViewSet(viewsets.ModelViewSet):

--- a/sale/views.py
+++ b/sale/views.py
@@ -4,6 +4,8 @@ from django.urls import reverse
 from django.contrib import messages
 from django.views.decorators.http import require_http_methods
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from .models import (
     SaleInvoice,
@@ -91,6 +93,16 @@ def sale_invoice_detail(request, pk):
 class SaleInvoiceViewSet(viewsets.ModelViewSet):
     queryset = SaleInvoice.objects.all().prefetch_related('items', 'recovery_logs')
     serializer_class = SaleInvoiceSerializer
+
+    @action(detail=False, methods=["get"], url_path="by-number/(?P<invoice_no>[^/.]+)")
+    def retrieve_by_number(self, request, invoice_no=None):
+        """Retrieve a sale invoice using its invoice_no."""
+        invoice = get_object_or_404(
+            SaleInvoice.objects.all().prefetch_related("items", "recovery_logs"),
+            invoice_no=invoice_no,
+        )
+        serializer = self.get_serializer(invoice)
+        return Response(serializer.data)
 
 
 class SaleReturnViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
- expose invoice lookup by `invoice_no` for sale and purchase APIs
- allow selecting an invoice when creating a sale or purchase return
- validate return items against original invoice quantities and batches

## Testing
- `python manage.py test` *(fails: OperationalError: table inventory_product has no column named company_id)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa669c9883299712d376cd14522f