### PR TITLE
Ensure POS invoices create vouchers

### DIFF
--- a/Frontend-PWD/components/POS.tsx
+++ b/Frontend-PWD/components/POS.tsx
@@ -139,6 +139,7 @@ const POS: React.FC = () => {
             paymentMethod,
             paidAmount: isPaid ? grandTotal : paidAmount,
         };
+        // Use the standard sale invoice API so backend voucher creation runs.
         await createSaleInvoice(saleData);
         clearCart();
     };

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# OKTTS
+
+## POS and voucher integration
+
+Point of Sale (POS) submissions reuse the existing sale invoice API at `/sales/invoices/`.  
+The `SaleInvoice` model automatically creates and links a `Voucher` when an invoice is saved, ensuring each POS-generated invoice has a corresponding accounting entry.
+
+A regression test at `sale/tests.py` verifies that a voucher is attached whenever an invoice is created via the API.

--- a/sale/models.py
+++ b/sale/models.py
@@ -5,9 +5,13 @@ from setting.models import Warehouse
 from inventory.models import Party, Product, Batch
 
 
+import logging
+
 from voucher.models import Voucher
 from utils.voucher import create_voucher_for_transaction
 from utils.stock import stock_return, stock_out
+
+logger = logging.getLogger(__name__)
 
 # Create your models here.
 class SaleInvoice(models.Model):
@@ -79,6 +83,7 @@ class SaleInvoice(models.Model):
             )
             self.voucher = voucher
             super().save(update_fields=['voucher'])
+            logger.info("Linked voucher %s to sale invoice %s", voucher.pk, self.pk)
 
 
 

--- a/sale/tests.py
+++ b/sale/tests.py
@@ -1,3 +1,100 @@
-from django.test import TestCase
+from datetime import date
 
-# Create your tests here.
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from inventory.models import Party, Product
+from setting.models import (
+    Area,
+    Branch,
+    City,
+    Company,
+    Distributor,
+    Group,
+    Warehouse,
+)
+from voucher.models import AccountType, ChartOfAccount, VoucherType
+from user.models import User
+from .models import SaleInvoice
+
+
+class SaleInvoiceVoucherLinkTest(APITestCase):
+    """Ensure a voucher is linked when invoices are created via the API."""
+
+    def setUp(self):
+        asset = AccountType.objects.create(name="ASSET")
+        income = AccountType.objects.create(name="INCOME")
+        self.customer_account = ChartOfAccount.objects.create(
+            name="Customer", code="1000", account_type=asset
+        )
+        self.sales_account = ChartOfAccount.objects.create(
+            name="Sales", code="4000", account_type=income
+        )
+        self.branch = Branch.objects.create(name="Main", address="addr")
+        self.warehouse = Warehouse.objects.create(
+            name="W1", branch=self.branch, default_sales_account=self.sales_account
+        )
+        self.city = City.objects.create(name="Metropolis")
+        self.area = Area.objects.create(name="Center", city=self.city)
+        company = Company.objects.create(name="C1")
+        group = Group.objects.create(name="G1")
+        distributor = Distributor.objects.create(name="D1")
+        self.product = Product.objects.create(
+            name="P1",
+            barcode="123",
+            company=company,
+            group=group,
+            distributor=distributor,
+            trade_price=10,
+            retail_price=10,
+            sales_tax_ratio=0,
+            fed_tax_ratio=0,
+            disable_sale_purchase=False,
+        )
+        self.customer = Party.objects.create(
+            name="Cust",
+            address="addr",
+            phone="123",
+            party_type="customer",
+            chart_of_account=self.customer_account,
+            city=self.city,
+            area=self.area,
+        )
+        VoucherType.objects.create(name="Sale", code="SAL")
+        self.user = User.objects.create_user("user@example.com", "pass")
+
+    def test_voucher_linked_on_creation(self):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "invoice_no": "INV-001",
+            "date": date.today().isoformat(),
+            "customer": self.customer.id,
+            "warehouse": self.warehouse.id,
+            "city_id": self.city.id,
+            "area_id": self.area.id,
+            "sub_total": "10.00",
+            "discount": "0",
+            "tax": "0",
+            "grand_total": "10.00",
+            "paid_amount": "10.00",
+            "net_amount": "10.00",
+            "payment_method": "Cash",
+            "status": "Paid",
+            "items": [
+                {
+                    "product": self.product.id,
+                    "quantity": 1,
+                    "bonus": 0,
+                    "packing": 0,
+                    "rate": "10.00",
+                    "discount1": 0,
+                    "discount2": 0,
+                    "amount": "10.00",
+                    "net_amount": "10.00",
+                }
+            ],
+        }
+        response = self.client.post("/sales/invoices/", payload, format="json")
+        self.assertEqual(response.status_code, 201, response.data)
+        invoice = SaleInvoice.objects.get(id=response.data["id"])
+        self.assertIsNotNone(invoice.voucher)


### PR DESCRIPTION
## Summary
- Log voucher linkage when saving sale invoices
- Add test asserting vouchers attach to POS-generated invoices
- Document POS sale invoice API usage and voucher integration

## Testing
- `python manage.py test sale.tests` *(fails: no such column: inventory_product.company_id)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa74ede4832994dc6c977419471b