### PR TITLE
Return saved entity from createEntity

### DIFF
--- a/Frontend-PWD/components/Management.tsx
+++ b/Frontend-PWD/components/Management.tsx
@@ -146,7 +146,7 @@ const Management: React.FC = () => {
             priceList: 'price-lists', priceListItem: 'price-lists',
         };
         const slug = slugMap[entityType];
-        const saved = modalMode === 'add'
+        const savedEntity = modalMode === 'add'
             ? await managementService.createEntity(slug, newItem)
             : await managementService.updateEntity(slug, newItem.id, newItem);
 
@@ -155,17 +155,17 @@ const Management: React.FC = () => {
         };
 
         switch (entityType) {
-            case 'branch': updateState(setBranches, saved); break;
-            case 'warehouse': updateState(setWarehouses, saved); break;
-            case 'city': updateState(setCities, saved); break;
-            case 'area': updateState(setAreas, saved); break;
-            case 'company': updateState(setCompanies, saved); break;
-            case 'group': updateState(setProductGroups, saved); break;
-            case 'distributor': updateState(setDistributors, saved); break;
-            case 'product': updateState(setProducts, saved); break;
-            case 'party': updateState(setParties, saved); break;
-            case 'account': updateState(setAccounts, saved); break;
-            case 'priceList': updateState(setPriceLists, saved); break;
+            case 'branch': updateState(setBranches, savedEntity); break;
+            case 'warehouse': updateState(setWarehouses, savedEntity); break;
+            case 'city': updateState(setCities, savedEntity); break;
+            case 'area': updateState(setAreas, savedEntity); break;
+            case 'company': updateState(setCompanies, savedEntity); break;
+            case 'group': updateState(setProductGroups, savedEntity); break;
+            case 'distributor': updateState(setDistributors, savedEntity); break;
+            case 'product': updateState(setProducts, savedEntity); break;
+            case 'party': updateState(setParties, savedEntity); break;
+            case 'account': updateState(setAccounts, savedEntity); break;
+            case 'priceList': updateState(setPriceLists, savedEntity); break;
         }
         closeModal();
     };

--- a/Frontend-PWD/services/management.ts
+++ b/Frontend-PWD/services/management.ts
@@ -21,13 +21,13 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
 export const getEntities = <T>(entity: string) =>
     request<T[]>(`${API_BASE}/${entity}/`);
 
-export const createEntity = <T>(entity: string, data: Partial<T>) =>{
+export const createEntity = <T>(entity: string, data: Partial<T>) => {
     console.log(entity, data);
-    request<T>(`${API_BASE}/${entity}/`, {
+    return request<T>(`${API_BASE}/${entity}/`, {
         method: 'POST',
         body: JSON.stringify(data),
     });
-}
+};
     
 
 export const updateEntity = <T>(entity: string, id: number, data: Partial<T>) =>


### PR DESCRIPTION
## Summary
- ensure `createEntity` resolves with the saved entity
- update `Management` component to use saved entity for state updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68962995067083299bade40c9e8eaec2