### PR TITLE
Use dedicated API routes for management data

### DIFF
--- a/Frontend-PWD/components/Management.tsx
+++ b/Frontend-PWD/components/Management.tsx
@@ -53,10 +53,10 @@ const Management: React.FC = () => {
                     managementService.getEntities<Company>('companies'),
                     managementService.getEntities<ProductGroup>('product-groups'),
                     managementService.getEntities<Distributor>('distributors'),
-                    //managementService.getEntities<Product>('products'),
-                   // managementService.getEntities<Party>('parties'),
-                   // managementService.getEntities<ChartOfAccount>('accounts'),
-                   // managementService.getEntities<PriceList>('price-lists'),
+                    managementService.getProducts(),
+                    managementService.getParties(),
+                    managementService.getAccounts(),
+                    managementService.getPriceLists(),
                 ]);
                 console.log('Fetched management data:', {citiesData, branchesData, warehousesData, areasData, companiesData, productGroupsData, distributorsData, productsData, partiesData, accountsData, priceListsData});
                 setBranches(branchesData);
@@ -66,10 +66,10 @@ const Management: React.FC = () => {
                 setCompanies(companiesData);
                 setProductGroups(productGroupsData);
                 setDistributors(distributorsData);
-                //setProducts(productsData);
-                //setParties(partiesData);
-                //setAccounts(accountsData);
-                //setPriceLists(priceListsData);
+                setProducts(productsData);
+                setParties(partiesData);
+                setAccounts(accountsData);
+                setPriceLists(priceListsData);
             } catch (err) {
                 console.error('Failed to load management data', err);
             }

--- a/Frontend-PWD/services/management.ts
+++ b/Frontend-PWD/services/management.ts
@@ -1,6 +1,10 @@
-import { PriceListItem } from '../types';
+import { ChartOfAccount, Party, PriceList, PriceListItem, Product } from '../types';
 
-const API_BASE = 'http://127.0.0.1:8000/api/management';
+const MANAGEMENT_API_BASE = 'http://127.0.0.1:8000/api/management';
+const INVENTORY_API_BASE = 'http://127.0.0.1:8000/api/inventory';
+const SALE_API_BASE = 'http://127.0.0.1:8000/api/sale';
+const VOUCHER_API_BASE = 'http://127.0.0.1:8000/api/voucher';
+const PRICING_API_BASE = 'http://127.0.0.1:8000/api/pricing';
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
     const token = localStorage.getItem('authToken');
@@ -19,11 +23,11 @@ async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
 }
 
 export const getEntities = <T>(entity: string) =>
-    request<T[]>(`${API_BASE}/${entity}/`);
+    request<T[]>(`${MANAGEMENT_API_BASE}/${entity}/`);
 
 export const createEntity = <T>(entity: string, data: Partial<T>) =>{
     console.log(entity, data);
-    request<T>(`${API_BASE}/${entity}/`, {
+    request<T>(`${MANAGEMENT_API_BASE}/${entity}/`, {
         method: 'POST',
         body: JSON.stringify(data),
     });
@@ -31,22 +35,34 @@ export const createEntity = <T>(entity: string, data: Partial<T>) =>{
     
 
 export const updateEntity = <T>(entity: string, id: number, data: Partial<T>) =>
-    request<T>(`${API_BASE}/${entity}/${id}/`, {
+    request<T>(`${MANAGEMENT_API_BASE}/${entity}/${id}/`, {
         method: 'PUT',
         body: JSON.stringify(data),
     });
 
+export const getProducts = () =>
+    request<Product[]>(`${INVENTORY_API_BASE}/products/`);
+
+export const getParties = () =>
+    request<Party[]>(`${SALE_API_BASE}/parties/`);
+
+export const getAccounts = () =>
+    request<ChartOfAccount[]>(`${VOUCHER_API_BASE}/accounts/`);
+
+export const getPriceLists = () =>
+    request<PriceList[]>(`${PRICING_API_BASE}/pricelists/`);
+
 export const getPriceListItems = (priceListId: number) =>
-    request<PriceListItem[]>(`${API_BASE}/price-lists/${priceListId}/items/`);
+    request<PriceListItem[]>(`${PRICING_API_BASE}/pricelists/${priceListId}/items/`);
 
 export const createPriceListItem = (priceListId: number, data: Partial<PriceListItem>) =>
-    request<PriceListItem>(`${API_BASE}/price-lists/${priceListId}/items/`, {
+    request<PriceListItem>(`${PRICING_API_BASE}/pricelists/${priceListId}/items/`, {
         method: 'POST',
         body: JSON.stringify(data),
     });
 
 export const updatePriceListItem = (priceListId: number, id: number, data: Partial<PriceListItem>) =>
-    request<PriceListItem>(`${API_BASE}/price-lists/${priceListId}/items/${id}/`, {
+    request<PriceListItem>(`${PRICING_API_BASE}/pricelists/${priceListId}/items/${id}/`, {
         method: 'PUT',
         body: JSON.stringify(data),
     });


### PR DESCRIPTION
## Summary
- support fetching accounts, parties, products, and price lists from their respective API modules
- update Management component to load data via new service functions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)
- `python manage.py test` (fails: No module named 'django')

------
https://chatgpt.com/codex/tasks/task_e_689629b34b208329a60b0632ae54f7e3