### PR TITLE
Expose pricing models and API endpoints

### DIFF
--- a/Frontend-PWD/components/Management.tsx
+++ b/Frontend-PWD/components/Management.tsx
@@ -5,6 +5,7 @@ import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
 import SearchableSelect from './SearchableSelect';
 import * as managementService from '../services/management';
+import * as pricingService from '../services/pricing';
 
 type ManagementTab = 'organization' | 'product_masters' | 'products' | 'parties' | 'pricing' | 'accounting';
 type EntityType = 'branch' | 'warehouse' | 'city' | 'area' | 'company' | 'group' | 'distributor' | 'product' | 'party' | 'account' | 'priceList' | 'priceListItem';
@@ -45,7 +46,7 @@ const Management: React.FC = () => {
     useEffect(() => {
         async function fetchData() {
             try {
-                const [branchesData, warehousesData, citiesData, areasData, companiesData, productGroupsData, distributorsData, productsData, partiesData, accountsData, priceListsData] = await Promise.all([
+                const [branchesData, warehousesData, citiesData, areasData, companiesData, productGroupsData, distributorsData, priceListsData] = await Promise.all([
                     managementService.getEntities<Branch>('branches'),
                     managementService.getEntities<Warehouse>('warehouses'),
                     managementService.getEntities<City>('cities'),
@@ -53,12 +54,9 @@ const Management: React.FC = () => {
                     managementService.getEntities<Company>('companies'),
                     managementService.getEntities<ProductGroup>('product-groups'),
                     managementService.getEntities<Distributor>('distributors'),
-                    //managementService.getEntities<Product>('products'),
-                   // managementService.getEntities<Party>('parties'),
-                   // managementService.getEntities<ChartOfAccount>('accounts'),
-                   // managementService.getEntities<PriceList>('price-lists'),
+                    pricingService.getPriceLists(),
                 ]);
-                console.log('Fetched management data:', {citiesData, branchesData, warehousesData, areasData, companiesData, productGroupsData, distributorsData, productsData, partiesData, accountsData, priceListsData});
+                console.log('Fetched management data:', {citiesData, branchesData, warehousesData, areasData, companiesData, productGroupsData, distributorsData, priceListsData});
                 setBranches(branchesData);
                 setWarehouses(warehousesData);
                 setCities(citiesData);
@@ -66,10 +64,7 @@ const Management: React.FC = () => {
                 setCompanies(companiesData);
                 setProductGroups(productGroupsData);
                 setDistributors(distributorsData);
-                //setProducts(productsData);
-                //setParties(partiesData);
-                //setAccounts(accountsData);
-                //setPriceLists(priceListsData);
+                setPriceLists(priceListsData);
             } catch (err) {
                 console.error('Failed to load management data', err);
             }
@@ -79,7 +74,7 @@ const Management: React.FC = () => {
 
     useEffect(() => {
         if (selectedPriceList) {
-            managementService.getPriceListItems(selectedPriceList.id)
+            pricingService.getPriceListItems(selectedPriceList.id)
                 .then(setPriceListItems)
                 .catch(err => console.error('Failed to load price list items', err));
         } else {
@@ -127,23 +122,27 @@ const Management: React.FC = () => {
 
     const handleSave = async (newItem: any) => {
         if (!entityType) return;
-        if (entityType === 'priceListItem') {
-            const priceListId = newItem.priceListId;
+        if (entityType === 'priceList') {
             const saved = modalMode === 'add'
-                ? await managementService.createPriceListItem(priceListId, newItem)
-                : await managementService.updatePriceListItem(priceListId, newItem.id, newItem);
-            setPriceListItems(prev => modalMode === 'add'
-                ? [...prev, saved]
-                : prev.map(i => i.id === saved.id ? saved : i));
+                ? await pricingService.createPriceList(newItem)
+                : await pricingService.updatePriceList(newItem.id, newItem);
+            setPriceLists(prev => modalMode === 'add' ? [...prev, saved] : prev.map(i => i.id === saved.id ? saved : i));
+            closeModal();
+            return;
+        }
+        if (entityType === 'priceListItem') {
+            const saved = modalMode === 'add'
+                ? await pricingService.createPriceListItem(newItem)
+                : await pricingService.updatePriceListItem(newItem.id, newItem);
+            setPriceListItems(prev => modalMode === 'add' ? [...prev, saved] : prev.map(i => i.id === saved.id ? saved : i));
             closeModal();
             return;
         }
 
-        const slugMap: Record<EntityType, string> = {
+        const slugMap: Record<string, string> = {
             branch: 'branches', warehouse: 'warehouses', city: 'cities', area: 'areas',
             company: 'companies', group: 'product-groups', distributor: 'distributors',
             product: 'products', party: 'parties', account: 'accounts',
-            priceList: 'price-lists', priceListItem: 'price-lists',
         };
         const slug = slugMap[entityType];
         const saved = modalMode === 'add'
@@ -165,7 +164,6 @@ const Management: React.FC = () => {
             case 'product': updateState(setProducts, saved); break;
             case 'party': updateState(setParties, saved); break;
             case 'account': updateState(setAccounts, saved); break;
-            case 'priceList': updateState(setPriceLists, saved); break;
         }
         closeModal();
     };
@@ -199,7 +197,7 @@ const Management: React.FC = () => {
                                 onEdit={(item) => openModal('priceListItem', 'edit', item)}
                                 columns={[
                                     { key: 'productId', label: 'Product', render: (val) => getDepName(val, products) }, 
-                                    { key: 'customPrice', label: 'Custom Price', render: val => `Rs. ${val.toFixed(2)}` }
+                                    { key: 'price', label: 'Price', render: val => `Rs. ${val.toFixed(2)}` }
                                 ]}
                             />
                         </div>
@@ -373,7 +371,7 @@ const ManagementFormModal: React.FC<{ entityType: any, mode: any, currentItem: a
                 return <>
                      <SearchableSelectWithLabel label="Price List" options={priceLists.map((p: PriceList) => ({ value: p.id, label: p.name }))} value={formData.priceListId || null} onChange={val => handleChange('priceListId', val)} disabled={!!formData.priceListId} />
                      <SearchableSelectWithLabel label="Product" options={products.map((p: Product) => ({ value: p.id, label: p.name }))} value={formData.productId || null} onChange={val => handleChange('productId', val)} />
-                     <FormInput label="Custom Price" name="customPrice" type="number" value={formData.customPrice || ''} onChange={handleInputChange} required className="md:col-span-2" />
+                     <FormInput label="Price" name="price" type="number" value={formData.price || ''} onChange={handleInputChange} required className="md:col-span-2" />
                 </>;
             default:
                 return null;

--- a/Frontend-PWD/components/POS.tsx
+++ b/Frontend-PWD/components/POS.tsx
@@ -66,7 +66,7 @@ const POS: React.FC = () => {
     useEffect(() => { if (paymentMethod === 'Cash') { setPaidAmount(grandTotal); } else { setPaidAmount(0); } }, [grandTotal, paymentMethod]);
     
     const addToCart = (product: Product) => {
-        const rate = selectedCustomerDetails?.priceListItems.find(p => p.productId === product.id)?.customPrice || product.retailPrice;
+        const rate = selectedCustomerDetails?.priceListItems.find(p => p.productId === product.id)?.price || product.retailPrice;
         const newItem: InvoiceItem = {
             id: new Date().getTime().toString(),
             productId: product.id,

--- a/Frontend-PWD/components/SaleInvoice.tsx
+++ b/Frontend-PWD/components/SaleInvoice.tsx
@@ -154,8 +154,8 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
                   if(!item.productId) return item;
                   const product = products.find(p => p.id === item.productId);
                   if (!product) return item;
-                  const customPriceItem = priceListId ? PRICE_LIST_ITEMS.find(pli => pli.priceListId === priceListId && pli.productId === product.id) : undefined;
-                  const rate = customPriceItem ? customPriceItem.customPrice : product.retailPrice;
+                  const priceListItem = priceListId ? PRICE_LIST_ITEMS.find(pli => pli.priceListId === priceListId && pli.productId === product.id) : undefined;
+                  const rate = priceListItem ? priceListItem.price : product.retailPrice;
                   const amount = item.quantity * rate;
                   const disc1Amount = amount * (item.discount1 / 100);
                   const amountAfterDisc1 = amount - disc1Amount;
@@ -217,8 +217,8 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
         if (field === 'productId' || field === 'batchId') {
             updatedItem.batchId = field === 'productId' ? null : updatedItem.batchId;
             if (product) {
-                const customPriceItem = selectedCustomerDetails?.priceListItems.find(p => p.productId === product.id);
-                updatedItem.rate = customPriceItem ? customPriceItem.customPrice : product.retailPrice;
+                const priceListItem = selectedCustomerDetails?.priceListItems.find(p => p.productId === product.id);
+                updatedItem.rate = priceListItem ? priceListItem.price : product.retailPrice;
             } else { updatedItem.rate = 0; }
         }
         

--- a/Frontend-PWD/components/constants.tsx
+++ b/Frontend-PWD/components/constants.tsx
@@ -255,16 +255,16 @@ export const PRICE_LISTS: PriceList[] = [
 
 export const PRICE_LIST_ITEMS: PriceListItem[] = [
     // Wholesale Prices
-    { id: 1, priceListId: 1, productId: 101, customPrice: 9.75 }, // Paracetamol
-    { id: 2, priceListId: 1, productId: 102, customPrice: 24.00 }, // Amoxicillin
-    { id: 3, priceListId: 1, productId: 201, customPrice: 42.00 }, // Moisturizing Cream
+    { id: 1, priceListId: 1, productId: 101, price: 9.75 }, // Paracetamol
+    { id: 2, priceListId: 1, productId: 102, price: 24.00 }, // Amoxicillin
+    { id: 3, priceListId: 1, productId: 201, price: 42.00 }, // Moisturizing Cream
     
     // Retail Chain Special
-    { id: 4, priceListId: 2, productId: 101, customPrice: 9.50 },
-    { id: 5, priceListId: 2, productId: 102, customPrice: 23.50 },
-    { id: 6, priceListId: 2, productId: 103, customPrice: 15.00 },
-    { id: 7, priceListId: 2, productId: 201, customPrice: 40.00 },
-    { id: 8, priceListId: 2, productId: 202, customPrice: 70.00 }
+    { id: 4, priceListId: 2, productId: 101, price: 9.50 },
+    { id: 5, priceListId: 2, productId: 102, price: 23.50 },
+    { id: 6, priceListId: 2, productId: 103, price: 15.00 },
+    { id: 7, priceListId: 2, productId: 201, price: 40.00 },
+    { id: 8, priceListId: 2, productId: 202, price: 70.00 }
 ];
 
 export const NOTIFICATIONS: Notification[] = [

--- a/Frontend-PWD/constants.tsx
+++ b/Frontend-PWD/constants.tsx
@@ -255,16 +255,16 @@ export const PRICE_LISTS: PriceList[] = [
 
 export const PRICE_LIST_ITEMS: PriceListItem[] = [
     // Wholesale Prices
-    { id: 1, priceListId: 1, productId: 101, customPrice: 9.75 }, // Paracetamol
-    { id: 2, priceListId: 1, productId: 102, customPrice: 24.00 }, // Amoxicillin
-    { id: 3, priceListId: 1, productId: 201, customPrice: 42.00 }, // Moisturizing Cream
+    { id: 1, priceListId: 1, productId: 101, price: 9.75 }, // Paracetamol
+    { id: 2, priceListId: 1, productId: 102, price: 24.00 }, // Amoxicillin
+    { id: 3, priceListId: 1, productId: 201, price: 42.00 }, // Moisturizing Cream
     
     // Retail Chain Special
-    { id: 4, priceListId: 2, productId: 101, customPrice: 9.50 },
-    { id: 5, priceListId: 2, productId: 102, customPrice: 23.50 },
-    { id: 6, priceListId: 2, productId: 103, customPrice: 15.00 },
-    { id: 7, priceListId: 2, productId: 201, customPrice: 40.00 },
-    { id: 8, priceListId: 2, productId: 202, customPrice: 70.00 }
+    { id: 4, priceListId: 2, productId: 101, price: 9.50 },
+    { id: 5, priceListId: 2, productId: 102, price: 23.50 },
+    { id: 6, priceListId: 2, productId: 103, price: 15.00 },
+    { id: 7, priceListId: 2, productId: 201, price: 40.00 },
+    { id: 8, priceListId: 2, productId: 202, price: 70.00 }
 ];
 
 export const NOTIFICATIONS: Notification[] = [

--- a/Frontend-PWD/services/management.ts
+++ b/Frontend-PWD/services/management.ts
@@ -1,5 +1,3 @@
-import { PriceListItem } from '../types';
-
 const API_BASE = 'http://127.0.0.1:8000/api/management';
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
@@ -36,17 +34,3 @@ export const updateEntity = <T>(entity: string, id: number, data: Partial<T>) =>
         body: JSON.stringify(data),
     });
 
-export const getPriceListItems = (priceListId: number) =>
-    request<PriceListItem[]>(`${API_BASE}/price-lists/${priceListId}/items/`);
-
-export const createPriceListItem = (priceListId: number, data: Partial<PriceListItem>) =>
-    request<PriceListItem>(`${API_BASE}/price-lists/${priceListId}/items/`, {
-        method: 'POST',
-        body: JSON.stringify(data),
-    });
-
-export const updatePriceListItem = (priceListId: number, id: number, data: Partial<PriceListItem>) =>
-    request<PriceListItem>(`${API_BASE}/price-lists/${priceListId}/items/${id}/`, {
-        method: 'PUT',
-        body: JSON.stringify(data),
-    });

--- a/Frontend-PWD/services/pricing.ts
+++ b/Frontend-PWD/services/pricing.ts
@@ -1,0 +1,77 @@
+import { PriceList, PriceListItem } from '../types';
+
+const API_BASE = 'http://127.0.0.1:8000/api/pricing';
+
+async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const token = localStorage.getItem('authToken');
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Token ${token}` } : {}),
+      ...(options.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  if (res.status === 204) {
+    return {} as T;
+  }
+  return res.json();
+}
+
+export const getPriceLists = () =>
+  request<PriceList[]>(`${API_BASE}/pricelists/`);
+
+export const createPriceList = (data: Partial<PriceList>) =>
+  request<PriceList>(`${API_BASE}/pricelists/`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+
+export const updatePriceList = (id: number, data: Partial<PriceList>) =>
+  request<PriceList>(`${API_BASE}/pricelists/${id}/`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+
+export const deletePriceList = (id: number) =>
+  request<void>(`${API_BASE}/pricelists/${id}/`, { method: 'DELETE' });
+
+export const getPriceListItems = (priceListId?: number) => {
+  const url = priceListId
+    ? `${API_BASE}/pricelist-items/?price_list=${priceListId}`
+    : `${API_BASE}/pricelist-items/`;
+  return request<PriceListItem[]>(url);
+};
+
+export const createPriceListItem = (data: Partial<PriceListItem>) => {
+  const payload = {
+    price_list: data.priceListId,
+    product: data.productId,
+    price: data.price,
+    description: data.description,
+  };
+  return request<PriceListItem>(`${API_BASE}/pricelist-items/`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+};
+
+export const updatePriceListItem = (id: number, data: Partial<PriceListItem>) => {
+  const payload = {
+    price_list: data.priceListId,
+    product: data.productId,
+    price: data.price,
+    description: data.description,
+  };
+  return request<PriceListItem>(`${API_BASE}/pricelist-items/${id}/`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  });
+};
+
+export const deletePriceListItem = (id: number) =>
+  request<void>(`${API_BASE}/pricelist-items/${id}/`, { method: 'DELETE' });
+

--- a/Frontend-PWD/types.ts
+++ b/Frontend-PWD/types.ts
@@ -442,7 +442,8 @@ export interface PriceListItem {
     id: number;
     priceListId: number;
     productId: number;
-    customPrice: number;
+    price: number;
+    description?: string;
 }
 
 // Notification Type

--- a/pricing/migrations/0002_add_descriptions.py
+++ b/pricing/migrations/0002_add_descriptions.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('pricing', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pricelist',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='pricelistitem',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+    ]

--- a/pricing/models.py
+++ b/pricing/models.py
@@ -3,6 +3,7 @@ from django.db import models
 
 class PriceList(models.Model):
     name = models.CharField(max_length=100)
+    description = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
@@ -13,6 +14,7 @@ class PriceListItem(models.Model):
     price_list = models.ForeignKey(PriceList, on_delete=models.CASCADE, related_name='items')
     product = models.ForeignKey('inventory.Product', on_delete=models.CASCADE)
     price = models.DecimalField(max_digits=10, decimal_places=2)
+    description = models.TextField(blank=True)
 
     def __str__(self):
         return f"{self.product.name} - {self.price}"

--- a/pricing/views.py
+++ b/pricing/views.py
@@ -1,5 +1,4 @@
 from rest_framework import viewsets
-from rest_framework import viewsets
 from .models import PriceList, PriceListItem
 from .serializers import PriceListSerializer, PriceListItemSerializer
 


### PR DESCRIPTION
## Summary
- add description fields to `PriceList` and `PriceListItem` with migration
- expose price list and item viewsets under `/api/pricing/`
- provide frontend pricing service and update types/components to use `price`

## Testing
- `python manage.py test pricing`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689629b69ae48329b4ee3999866c0c77