### PR TITLE
Add party and account APIs with frontend integration

### DIFF
--- a/Frontend-PWD/components/Management.tsx
+++ b/Frontend-PWD/components/Management.tsx
@@ -5,6 +5,8 @@ import { FilterBar, FilterControls } from './FilterBar';
 import { SearchInput } from './SearchInput';
 import SearchableSelect from './SearchableSelect';
 import * as managementService from '../services/management';
+import * as inventoryService from '../services/inventory';
+import * as voucherService from '../services/voucher';
 
 type ManagementTab = 'organization' | 'product_masters' | 'products' | 'parties' | 'pricing' | 'accounting';
 type EntityType = 'branch' | 'warehouse' | 'city' | 'area' | 'company' | 'group' | 'distributor' | 'product' | 'party' | 'account' | 'priceList' | 'priceListItem';
@@ -45,7 +47,7 @@ const Management: React.FC = () => {
     useEffect(() => {
         async function fetchData() {
             try {
-                const [branchesData, warehousesData, citiesData, areasData, companiesData, productGroupsData, distributorsData, productsData, partiesData, accountsData, priceListsData] = await Promise.all([
+                const [branchesData, warehousesData, citiesData, areasData, companiesData, productGroupsData, distributorsData, partiesData, accountsData] = await Promise.all([
                     managementService.getEntities<Branch>('branches'),
                     managementService.getEntities<Warehouse>('warehouses'),
                     managementService.getEntities<City>('cities'),
@@ -53,12 +55,10 @@ const Management: React.FC = () => {
                     managementService.getEntities<Company>('companies'),
                     managementService.getEntities<ProductGroup>('product-groups'),
                     managementService.getEntities<Distributor>('distributors'),
-                    //managementService.getEntities<Product>('products'),
-                   // managementService.getEntities<Party>('parties'),
-                   // managementService.getEntities<ChartOfAccount>('accounts'),
-                   // managementService.getEntities<PriceList>('price-lists'),
+                    inventoryService.fetchParties(),
+                    voucherService.fetchChartOfAccounts(),
                 ]);
-                console.log('Fetched management data:', {citiesData, branchesData, warehousesData, areasData, companiesData, productGroupsData, distributorsData, productsData, partiesData, accountsData, priceListsData});
+                console.log('Fetched management data:', {citiesData, branchesData, warehousesData, areasData, companiesData, productGroupsData, distributorsData, partiesData, accountsData});
                 setBranches(branchesData);
                 setWarehouses(warehousesData);
                 setCities(citiesData);
@@ -66,10 +66,8 @@ const Management: React.FC = () => {
                 setCompanies(companiesData);
                 setProductGroups(productGroupsData);
                 setDistributors(distributorsData);
-                //setProducts(productsData);
-                //setParties(partiesData);
-                //setAccounts(accountsData);
-                //setPriceLists(priceListsData);
+                setParties(partiesData);
+                setAccounts(accountsData);
             } catch (err) {
                 console.error('Failed to load management data', err);
             }

--- a/Frontend-PWD/services/inventory.ts
+++ b/Frontend-PWD/services/inventory.ts
@@ -1,6 +1,6 @@
 import { Product, Party } from '../types';
 
-const API_BASE = 'http://127.0.0.1:8000/inventory';
+const API_BASE = 'http://127.0.0.1:8000/api/inventory';
 
 async function request<T>(url: string): Promise<T> {
   const res = await fetch(url, { headers: { 'Content-Type': 'application/json' } });

--- a/Frontend-PWD/services/voucher.ts
+++ b/Frontend-PWD/services/voucher.ts
@@ -1,0 +1,14 @@
+import { ChartOfAccount } from '../types';
+
+const API_BASE = 'http://127.0.0.1:8000/api/voucher';
+
+async function request<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+
+export const fetchChartOfAccounts = () =>
+  request<ChartOfAccount[]>(`${API_BASE}/chart-of-accounts/`);

--- a/erp/urls.py
+++ b/erp/urls.py
@@ -27,7 +27,8 @@ urlpatterns = [
 
 
 
-    path('inventory/', include('inventory.urls')),
+    path('api/inventory/', include('inventory.urls')),
+    path('api/voucher/', include('voucher.urls')),
 
     path('api/crm/', include('crm.urls')),
     path('api/tasks/', include('task.urls')),

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import Party
+
+
+class PartySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Party
+        fields = '__all__'

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -1,7 +1,15 @@
 from django.urls import path
+from rest_framework.routers import DefaultRouter
+
 from . import views
+
+router = DefaultRouter()
+router.register('parties', views.PartyViewSet)
+
 
 urlpatterns = [
     path('price-lists/', views.price_list_list, name='price_list_list'),
     path('price-lists/<int:pk>/', views.price_list_detail, name='price_list_detail'),
 ]
+
+urlpatterns += router.urls

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,7 +1,10 @@
 from django.shortcuts import get_object_or_404
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
-from .models import PriceList
+from rest_framework import viewsets
+
+from .models import PriceList, Party
+from .serializers import PartySerializer
 
 
 @require_http_methods(["GET"])
@@ -23,3 +26,10 @@ def price_list_detail(request, pk):
         'items': list(items)
     }
     return JsonResponse(data)
+
+
+class PartyViewSet(viewsets.ModelViewSet):
+    """API endpoint for managing parties."""
+
+    queryset = Party.objects.all()
+    serializer_class = PartySerializer

--- a/voucher/serializers.py
+++ b/voucher/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import ChartOfAccount
+
+
+class ChartOfAccountSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ChartOfAccount
+        fields = '__all__'

--- a/voucher/urls.py
+++ b/voucher/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import ChartOfAccountViewSet
+
+router = DefaultRouter()
+router.register('chart-of-accounts', ChartOfAccountViewSet)
+
+urlpatterns = router.urls

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -1,3 +1,11 @@
-from django.shortcuts import render
+from rest_framework import viewsets
 
-# Create your views here.
+from .models import ChartOfAccount
+from .serializers import ChartOfAccountSerializer
+
+
+class ChartOfAccountViewSet(viewsets.ModelViewSet):
+    """API endpoint for managing chart of accounts."""
+
+    queryset = ChartOfAccount.objects.all()
+    serializer_class = ChartOfAccountSerializer


### PR DESCRIPTION
## Summary
- expose CRUD endpoints for parties and chart of accounts
- wire up inventory and voucher routers under /api
- update frontend services and management view to consume new APIs

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_689629b6ebec832992450d2f5a74b71c