### PR TITLE
Add drf-spectacular schema endpoint

### DIFF
--- a/erp/settings.py
+++ b/erp/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'rest_framework.authtoken',
+    'drf_spectacular',
     'hr',
     'setting',
     'inventory',
@@ -82,7 +83,8 @@ REST_FRAMEWORK = {
                 'rest_framework.authentication.TokenAuthentication',
                 'rest_framework.authentication.SessionAuthentication',
             ],
-           
+            'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+
         }
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/erp/urls.py
+++ b/erp/urls.py
@@ -17,6 +17,11 @@ Including another URLconf
 from django.contrib import admin
 
 from django.urls import include, path
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 
 
 urlpatterns = [
@@ -44,4 +49,7 @@ urlpatterns = [
 
 
 
+    path('spectacular/', SpectacularAPIView.as_view(), name='schema'),
+    path('spectacular/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('spectacular/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]


### PR DESCRIPTION
## Summary
- enable drf-spectacular in installed apps and REST framework
- expose schema, Swagger, and Redoc views at /spectacular/

## Testing
- `python manage.py test` *(fails: ImportError cannot import name 'User' from 'user.models')*


------
https://chatgpt.com/codex/tasks/task_e_68975c797ba88329b7a5c95ba1bcae24