### PR TITLE
Remove username from UserSerializer

### DIFF
--- a/user/serializers.py
+++ b/user/serializers.py
@@ -9,7 +9,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CustomUser
-        fields = ("id", "username", "email", "role")
+        fields = ("id", "email", "role")
 
 
 class AuthTokenSerializer(serializers.Serializer):


### PR DESCRIPTION
## Summary
- simplify UserSerializer to expose only id, email and role

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897681e8034832990fb455e1c28fd00