### PR TITLE
Add inventory stock levels API

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,7 +1,9 @@
 from django.urls import reverse
 from django.test import TestCase
-from setting.models import Company, Group, Distributor
-from .models import Product, PriceList, PriceListItem
+from datetime import date
+
+from setting.models import Company, Group, Distributor, Branch, Warehouse
+from .models import Product, PriceList, PriceListItem, Batch
 
 
 class PriceListAPITest(TestCase):
@@ -32,3 +34,74 @@ class PriceListAPITest(TestCase):
         self.assertEqual(data['name'], 'List')
         self.assertEqual(len(data['items']), 1)
         self.assertEqual(data['items'][0]['custom_price'], '8.00')
+
+
+class InventoryLevelsAPITest(TestCase):
+    def setUp(self):
+        company = Company.objects.create(name="Comp")
+        group = Group.objects.create(name="Grp")
+        distributor = Distributor.objects.create(name="Dist")
+        branch = Branch.objects.create(name="Main", address="Addr")
+        warehouse = Warehouse.objects.create(name="W1", branch=branch)
+
+        self.p1 = Product.objects.create(
+            name="Prod1",
+            barcode="111",
+            company=company,
+            group=group,
+            distributor=distributor,
+            trade_price=10,
+            retail_price=12,
+            sales_tax_ratio=1,
+            fed_tax_ratio=1,
+            disable_sale_purchase=False,
+        )
+        self.p2 = Product.objects.create(
+            name="Prod2",
+            barcode="222",
+            company=company,
+            group=group,
+            distributor=distributor,
+            trade_price=20,
+            retail_price=25,
+            sales_tax_ratio=1,
+            fed_tax_ratio=1,
+            disable_sale_purchase=False,
+        )
+
+        Batch.objects.create(
+            product=self.p1,
+            batch_number="B1",
+            expiry_date=date.today(),
+            purchase_price=5,
+            sale_price=8,
+            quantity=10,
+            warehouse=warehouse,
+        )
+        Batch.objects.create(
+            product=self.p1,
+            batch_number="B2",
+            expiry_date=date.today(),
+            purchase_price=5,
+            sale_price=8,
+            quantity=5,
+            warehouse=warehouse,
+        )
+        Batch.objects.create(
+            product=self.p2,
+            batch_number="B3",
+            expiry_date=date.today(),
+            purchase_price=7,
+            sale_price=9,
+            quantity=7,
+            warehouse=warehouse,
+        )
+
+    def test_inventory_levels_endpoint(self):
+        url = reverse('inventory_levels')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        levels = {item['product']['id']: item['totalStock'] for item in data['levels']}
+        self.assertEqual(levels[self.p1.id], 15)
+        self.assertEqual(levels[self.p2.id], 7)

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('price-lists/', views.price_list_list, name='price_list_list'),
     path('price-lists/<int:pk>/', views.price_list_detail, name='price_list_detail'),
+    path('levels/', views.inventory_levels, name='inventory_levels'),
 ]


### PR DESCRIPTION
## Summary
- add `/inventory/levels` endpoint to aggregate stock by product
- include tests for stock level aggregation

## Testing
- `python manage.py test inventory -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6897688e24b483299893c0dbc542fda3