### PR TITLE
Add stock audit endpoint

### DIFF
--- a/inventory/tests.py
+++ b/inventory/tests.py
@@ -1,7 +1,11 @@
-from django.urls import reverse
+import json
+from datetime import date, timedelta
+
 from django.test import TestCase
-from setting.models import Company, Group, Distributor
-from .models import Product, PriceList, PriceListItem
+from django.urls import reverse
+
+from setting.models import Branch, Company, Distributor, Group, Warehouse
+from .models import Batch, PriceList, PriceListItem, Product, StockMovement
 
 
 class PriceListAPITest(TestCase):
@@ -32,3 +36,67 @@ class PriceListAPITest(TestCase):
         self.assertEqual(data['name'], 'List')
         self.assertEqual(len(data['items']), 1)
         self.assertEqual(data['items'][0]['custom_price'], '8.00')
+
+
+class StockAuditAPITest(TestCase):
+    def setUp(self):
+        company = Company.objects.create(name="Comp")
+        group = Group.objects.create(name="Grp")
+        distributor = Distributor.objects.create(name="Dist")
+        branch = Branch.objects.create(name="Main", address="addr", sale_invoice_footer="")
+        warehouse = Warehouse.objects.create(name="WH", branch=branch)
+        self.product = Product.objects.create(
+            name="Prod",
+            barcode="123",
+            company=company,
+            group=group,
+            distributor=distributor,
+            trade_price=10,
+            retail_price=12,
+            sales_tax_ratio=1,
+            fed_tax_ratio=1,
+            disable_sale_purchase=False,
+        )
+        self.batch1 = Batch.objects.create(
+            product=self.product,
+            batch_number="B1",
+            expiry_date=date.today() + timedelta(days=30),
+            purchase_price=5,
+            sale_price=6,
+            quantity=10,
+            warehouse=warehouse,
+        )
+        self.batch2 = Batch.objects.create(
+            product=self.product,
+            batch_number="B2",
+            expiry_date=date.today() + timedelta(days=60),
+            purchase_price=5,
+            sale_price=6,
+            quantity=5,
+            warehouse=warehouse,
+        )
+
+    def test_audit_updates_stock_and_records_movements(self):
+        url = reverse('inventory_audit')
+        payload = {
+            "batches": [
+                {"batch_id": self.batch1.id, "count": 8},
+                {"batch_id": self.batch2.id, "count": 7},
+            ]
+        }
+        response = self.client.post(
+            url, data=json.dumps(payload), content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.batch1.refresh_from_db()
+        self.batch2.refresh_from_db()
+        self.assertEqual(self.batch1.quantity, 8)
+        self.assertEqual(self.batch2.quantity, 7)
+
+        movements = StockMovement.objects.order_by('batch__batch_number')
+        self.assertEqual(movements.count(), 2)
+        self.assertEqual(movements[0].movement_type, 'ADJUST')
+        self.assertEqual(movements[0].quantity, -2)
+        self.assertEqual(movements[1].movement_type, 'ADJUST')
+        self.assertEqual(movements[1].quantity, 2)

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -4,4 +4,5 @@ from . import views
 urlpatterns = [
     path('price-lists/', views.price_list_list, name='price_list_list'),
     path('price-lists/<int:pk>/', views.price_list_detail, name='price_list_detail'),
+    path('audit/', views.stock_audit, name='inventory_audit'),
 ]

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,7 +1,11 @@
-from django.shortcuts import get_object_or_404
+import json
+
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
-from .models import PriceList
+
+from .models import Batch, PriceList, StockMovement
 
 
 @require_http_methods(["GET"])
@@ -23,3 +27,45 @@ def price_list_detail(request, pk):
         'items': list(items)
     }
     return JsonResponse(data)
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def stock_audit(request):
+    """Adjust stock levels based on provided physical counts.
+
+    Expects a JSON payload with a ``batches`` key containing objects with
+    ``batch_id`` and ``count``. For each batch the quantity is updated and a
+    ``StockMovement`` entry with ``movement_type='ADJUST'`` is recorded.
+    """
+
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    results = []
+    for item in payload.get("batches", []):
+        batch_id = item.get("batch_id")
+        count = item.get("count")
+        if batch_id is None or count is None:
+            continue
+
+        batch = get_object_or_404(Batch, pk=batch_id)
+        variance = int(count) - batch.quantity
+
+        if variance != 0:
+            batch.quantity = count
+            batch.save()
+            StockMovement.objects.create(
+                batch=batch,
+                movement_type="ADJUST",
+                quantity=variance,
+                reason="Stock audit adjustment",
+            )
+
+        results.append(
+            {"batch_id": batch_id, "variance": variance, "new_quantity": batch.quantity}
+        )
+
+    return JsonResponse({"results": results})


### PR DESCRIPTION
## Summary
- add `/inventory/audit` endpoint to adjust batch stock and log `StockMovement`
- expose audit endpoint through inventory URLs
- test that endpoint updates quantities and creates movement entries

## Testing
- `python manage.py test inventory`
- `python manage.py test` *(fails: ImportError: cannot import name 'User' from 'user.models')*

------
https://chatgpt.com/codex/tasks/task_e_6897688f86fc8329af62b6d0da30c887