### PR TITLE
Add customer ledger endpoint

### DIFF
--- a/erp/urls.py
+++ b/erp/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 from django.contrib import admin
 
 from django.urls import include, path
+from voucher.views import customer_ledger
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
@@ -33,6 +34,8 @@ urlpatterns = [
 
 
     path('inventory/', include('inventory.urls')),
+
+    path('financials/ledger/customer/<int:party_id>/', customer_ledger, name='customer_ledger'),
 
     path('api/crm/', include('crm.urls')),
     path('api/tasks/', include('task.urls')),

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -1,3 +1,47 @@
-from django.shortcuts import render
+"""Views for voucher and financial ledger endpoints."""
 
-# Create your views here.
+from decimal import Decimal
+
+from django.shortcuts import get_object_or_404
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from inventory.models import Party
+from .models import VoucherEntry
+
+
+@api_view(["GET"])
+def customer_ledger(request, party_id):
+    """Return voucher history for a customer `Party`.
+
+    The ledger is built from :class:`VoucherEntry` records tied to the
+    party's chart of account. Entries are ordered by voucher date and a
+    running balance is calculated server-side.
+    """
+
+    party = get_object_or_404(Party, pk=party_id, party_type="customer")
+
+    if not party.chart_of_account:
+        return Response({"party": party.id, "ledger": []})
+
+    entries = (
+        VoucherEntry.objects.filter(account=party.chart_of_account)
+        .select_related("voucher")
+        .order_by("voucher__date", "id")
+    )
+
+    balance = Decimal("0")
+    ledger = []
+    for entry in entries:
+        balance += entry.debit - entry.credit
+        ledger.append(
+            {
+                "date": entry.voucher.date,
+                "description": entry.voucher.narration or entry.remarks,
+                "debit": float(entry.debit),
+                "credit": float(entry.credit),
+                "balance": float(balance),
+            }
+        )
+
+    return Response({"party": party.id, "party_name": party.name, "ledger": ledger})


### PR DESCRIPTION
## Summary
- expose `/financials/ledger/customer/<party_id>` API that returns voucher history for a customer party with running balance
- register route in project URLs

## Testing
- `python manage.py test` *(fails: ImportError: cannot import name 'User' from 'user.models')*

------
https://chatgpt.com/codex/tasks/task_e_68976890801c832984394ae4c2ef6915