### PR TITLE
Add investor list and ledger endpoints

### DIFF
--- a/investor/serializers.py
+++ b/investor/serializers.py
@@ -1,8 +1,15 @@
 from rest_framework import serializers
+from inventory.models import Party
 from .models import InvestorTransaction
 
 
 class InvestorTransactionSerializer(serializers.ModelSerializer):
     class Meta:
         model = InvestorTransaction
+        fields = '__all__'
+
+
+class PartySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Party
         fields = '__all__'

--- a/investor/urls.py
+++ b/investor/urls.py
@@ -1,7 +1,8 @@
 from rest_framework.routers import DefaultRouter
-from .views import InvestorTransactionViewSet
+from .views import InvestorTransactionViewSet, InvestorViewSet
 
 router = DefaultRouter()
 router.register(r'transactions', InvestorTransactionViewSet)
+router.register(r'investors', InvestorViewSet, basename='investor')
 
 urlpatterns = router.urls

--- a/investor/views.py
+++ b/investor/views.py
@@ -1,8 +1,47 @@
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from inventory.models import Party
 from .models import InvestorTransaction
-from .serializers import InvestorTransactionSerializer
+from .serializers import InvestorTransactionSerializer, PartySerializer
 
 
 class InvestorTransactionViewSet(viewsets.ModelViewSet):
     queryset = InvestorTransaction.objects.all()
     serializer_class = InvestorTransactionSerializer
+
+
+class InvestorViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Party.objects.filter(party_type="investor")
+    serializer_class = PartySerializer
+
+    @action(detail=True, methods=["get"])
+    def ledger(self, request, pk=None):
+        investor = self.get_object()
+        transactions = InvestorTransaction.objects.filter(
+            investor=investor
+        ).order_by("date", "id")
+
+        balance = 0
+        ledger_entries = []
+        for tx in transactions:
+            if tx.transaction_type == "IN":
+                credit = tx.amount
+                debit = 0
+                balance += credit
+            else:
+                credit = 0
+                debit = tx.amount
+                balance -= debit
+
+            ledger_entries.append(
+                {
+                    "date": tx.date,
+                    "description": tx.description,
+                    "debit": debit,
+                    "credit": credit,
+                    "balance": balance,
+                }
+            )
+
+        return Response(ledger_entries)


### PR DESCRIPTION
## Summary
- expose Party records tagged as investors via `/investors`
- provide `/investors/<id>/ledger` to compute running balance from transactions

## Testing
- `python manage.py test investor`

------
https://chatgpt.com/codex/tasks/task_e_68976896191c83299060a84b9fc8c1fb