### PR TITLE
Add aggregated management endpoint

### DIFF
--- a/setting/urls.py
+++ b/setting/urls.py
@@ -9,6 +9,7 @@ from .views import (
     DistributorViewSet,
     BranchViewSet,
     WarehouseViewSet,
+    management_all,
 )
 
 
@@ -22,5 +23,6 @@ router.register(r'branches', BranchViewSet)
 router.register(r'warehouses', WarehouseViewSet)
 
 urlpatterns = [
+    path('all/', management_all),
     path('', include(router.urls)),
 ]

--- a/setting/views.py
+++ b/setting/views.py
@@ -1,4 +1,6 @@
 from rest_framework import permissions, viewsets
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
 
 from .models import City, Area, Company, Group, Distributor, Branch, Warehouse
 from .serializers import (
@@ -10,6 +12,9 @@ from .serializers import (
     BranchSerializer,
     WarehouseSerializer,
 )
+from inventory.models import Party, Product, Batch, PriceList, PriceListItem
+from expense.models import ExpenseCategory
+from voucher.models import ChartOfAccount
 
 
 class CityViewSet(viewsets.ModelViewSet):
@@ -52,3 +57,23 @@ class WarehouseViewSet(viewsets.ModelViewSet):
     queryset = Warehouse.objects.all()
     serializer_class = WarehouseSerializer
     permission_classes = [permissions.IsAuthenticated]
+
+
+@api_view(["GET"])
+@permission_classes([permissions.IsAuthenticated])
+def management_all(request):
+    data = {
+        "companies": list(Company.objects.values()),
+        "groups": list(Group.objects.values()),
+        "distributors": list(Distributor.objects.values()),
+        "cities": list(City.objects.values()),
+        "areas": list(Area.objects.values()),
+        "parties": list(Party.objects.values()),
+        "products": list(Product.objects.values()),
+        "batches": list(Batch.objects.values()),
+        "expense_categories": list(ExpenseCategory.objects.values()),
+        "price_lists": list(PriceList.objects.values()),
+        "price_list_items": list(PriceListItem.objects.values()),
+        "chart_of_accounts": list(ChartOfAccount.objects.values()),
+    }
+    return Response(data)


### PR DESCRIPTION
## Summary
- Add `management_all` view returning consolidated data for core entities
- Wire up `/api/management/all/` route for the new view

## Testing
- `python manage.py test` *(fails: ImportError: cannot import name 'User' from 'user.models')*

------
https://chatgpt.com/codex/tasks/task_e_68976897a4e4832989275420359c7074