### PR TITLE
Expose product and party APIs

### DIFF
--- a/Frontend-PWD/components/PurchaseInvoice.tsx
+++ b/Frontend-PWD/components/PurchaseInvoice.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { PurchaseInvoice, PurchaseInvoiceItem, Task, InvoiceStatus, Product, Party } from '../types';
 import { EMPLOYEES, ICONS } from '../constants';
-import { fetchProducts, fetchParties } from '../services/inventory';
+import { getProducts, getParties } from '../services/inventory';
 import SearchableSelect from './SearchableSelect';
 import { createPurchaseInvoice, updatePurchaseInvoice } from '../services/purchase';
 
@@ -64,8 +64,8 @@ const PurchaseInvoiceForm: React.FC<PurchaseInvoiceProps> = ({ invoiceToEdit, ha
   }, [invoiceToEdit, isEditMode]);
 
   useEffect(() => {
-    fetchProducts().then(setProducts).catch(() => setProducts([]));
-    fetchParties().then(setParties).catch(() => setParties([]));
+    getProducts().then(setProducts).catch(() => setProducts([]));
+    getParties().then(setParties).catch(() => setParties([]));
   }, []);
   const investors = useMemo(() => parties.filter(p => p.partyType === 'investor'), [parties]);
   const suppliers = useMemo(() => parties.filter(p => p.partyType === 'supplier'), [parties]);

--- a/Frontend-PWD/components/PurchaseReturn.tsx
+++ b/Frontend-PWD/components/PurchaseReturn.tsx
@@ -8,7 +8,7 @@ import { createPurchaseReturn, updatePurchaseReturn, fetchPurchaseInvoices, fetc
 import {  Product, Party } from '../types';
 
 
-import { fetchProducts, fetchParties } from '../services/inventory';
+import { getProducts, getParties } from '../services/inventory';
 
 
 interface PurchaseReturnProps {
@@ -52,8 +52,8 @@ const PurchaseReturnForm: React.FC<PurchaseReturnProps> = ({ returnToEdit, handl
   useEffect(() => {
     fetchPurchaseInvoices().then(setInvoices).catch(() => {});
 
-    fetchProducts().then(setProducts).catch(() => setProducts([]));
-    fetchParties().then(setParties).catch(() => setParties([]));
+    getProducts().then(setProducts).catch(() => setProducts([]));
+    getParties().then(setParties).catch(() => setParties([]));
 
   }, []);
 

--- a/Frontend-PWD/components/SaleInvoice.tsx
+++ b/Frontend-PWD/components/SaleInvoice.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Order, InvoiceItem, Party, Area, PriceListItem, Task, Product, City } from '../types';
 import { BATCHES, ICONS, EMPLOYEES, COMPANIES, PRICE_LISTS, PRICE_LIST_ITEMS } from '../constants';
-import { fetchProducts, fetchParties } from '../services/inventory';
+import { getProducts, getParties } from '../services/inventory';
 import { fetchCities, fetchAreas } from '../services/settings';
 import SearchableSelect from './SearchableSelect';
 import { addToSyncQueue, registerSync } from '../services/db';
@@ -73,8 +73,8 @@ const SaleInvoice: React.FC<SaleInvoiceProps> = ({ invoiceToEdit, handleClose })
   }, [invoiceToEdit, isEditMode]);
 
   useEffect(() => {
-    fetchProducts().then(setProducts).catch(() => setProducts([]));
-    fetchParties().then(setParties).catch(() => setParties([]));
+    getProducts().then(setProducts).catch(() => setProducts([]));
+    getParties().then(setParties).catch(() => setParties([]));
     Promise.all([fetchCities(), fetchAreas()])
       .then(([c, a]) => {
         setCities(c);

--- a/Frontend-PWD/components/SaleReturn.tsx
+++ b/Frontend-PWD/components/SaleReturn.tsx
@@ -9,7 +9,7 @@ import { Product, Party } from '../types';
 
 
 
-import { fetchProducts, fetchParties } from '../services/inventory';
+import { getProducts, getParties } from '../services/inventory';
 
 
 interface SaleReturnProps {
@@ -54,8 +54,8 @@ const SaleReturnForm: React.FC<SaleReturnProps> = ({ returnToEdit, handleClose }
 
     listSaleInvoices().then(setInvoices).catch(() => {});
 
-    fetchProducts().then(setProducts).catch(() => setProducts([]));
-    fetchParties().then(setParties).catch(() => setParties([]));
+    getProducts().then(setProducts).catch(() => setProducts([]));
+    getParties().then(setParties).catch(() => setParties([]));
 
   }, []);
 

--- a/Frontend-PWD/services/inventory.ts
+++ b/Frontend-PWD/services/inventory.ts
@@ -10,5 +10,5 @@ async function request<T>(url: string): Promise<T> {
   return res.json();
 }
 
-export const fetchProducts = () => request<Product[]>(`${API_BASE}/products/`);
-export const fetchParties = () => request<Party[]>(`${API_BASE}/parties/`);
+export const getProducts = () => request<Product[]>(`${API_BASE}/products/`);
+export const getParties = () => request<Party[]>(`${API_BASE}/parties/`);

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -5,4 +5,6 @@ urlpatterns = [
     path('price-lists/', views.price_list_list, name='price_list_list'),
     path('price-lists/<int:pk>/', views.price_list_detail, name='price_list_detail'),
     path('levels/', views.inventory_levels, name='inventory_levels'),
+    path('products/', views.product_list, name='product_list'),
+    path('parties/', views.party_list, name='party_list'),
 ]

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import get_object_or_404
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
 from django.db.models import Sum
-from .models import PriceList, Batch
+from .models import PriceList, Batch, Product, Party
 
 
 @require_http_methods(["GET"])
@@ -42,3 +42,83 @@ def inventory_levels(request):
         for item in levels
     ]
     return JsonResponse({"levels": data})
+
+
+@require_http_methods(["GET"])
+def product_list(request):
+    """Return all products with camelCase keys."""
+    products = Product.objects.values(
+        "id",
+        "name",
+        "barcode",
+        "company_id",
+        "group_id",
+        "distributor_id",
+        "trade_price",
+        "retail_price",
+        "sales_tax_ratio",
+        "fed_tax_ratio",
+        "disable_sale_purchase",
+    )
+    data = [
+        {
+            "id": p["id"],
+            "name": p["name"],
+            "barcode": p["barcode"],
+            "companyId": p["company_id"],
+            "groupId": p["group_id"],
+            "distributorId": p["distributor_id"],
+            "tradePrice": float(p["trade_price"]),
+            "retailPrice": float(p["retail_price"]),
+            "salesTaxRatio": float(p["sales_tax_ratio"]),
+            "fedTaxRatio": float(p["fed_tax_ratio"]),
+            "disableSalePurchase": p["disable_sale_purchase"],
+        }
+        for p in products
+    ]
+    return JsonResponse(data, safe=False)
+
+
+@require_http_methods(["GET"])
+def party_list(request):
+    """Return all parties with camelCase keys."""
+    parties = Party.objects.values(
+        "id",
+        "name",
+        "address",
+        "phone",
+        "party_type",
+        "city_id",
+        "area_id",
+        "proprietor",
+        "license_no",
+        "license_expiry",
+        "category",
+        "latitude",
+        "longitude",
+        "credit_limit",
+        "current_balance",
+        "price_list",
+    )
+    data = [
+        {
+            "id": p["id"],
+            "name": p["name"],
+            "address": p["address"],
+            "phone": p["phone"],
+            "partyType": p["party_type"],
+            "cityId": p["city_id"],
+            "areaId": p["area_id"],
+            "proprietor": p["proprietor"],
+            "licenseNo": p["license_no"],
+            "licenseExpiry": p["license_expiry"],
+            "category": p["category"],
+            "latitude": p["latitude"],
+            "longitude": p["longitude"],
+            "creditLimit": float(p["credit_limit"]) if p["credit_limit"] is not None else None,
+            "currentBalance": float(p["current_balance"]) if p["current_balance"] is not None else None,
+            "priceListId": int(p["price_list"]) if p["price_list"] and str(p["price_list"]).isdigit() else None,
+        }
+        for p in parties
+    ]
+    return JsonResponse(data, safe=False)


### PR DESCRIPTION
## Summary
- add product and party list API endpoints to inventory backend
- rename inventory service calls to getProducts/getParties and update components

## Testing
- `python manage.py test inventory`

------
https://chatgpt.com/codex/tasks/task_e_68a08593d5dc83298ee80baea45faf68