### PR TITLE
Use correct API paths and expose voucher accounts endpoint

### DIFF
--- a/Frontend-PWD/services/management.ts
+++ b/Frontend-PWD/services/management.ts
@@ -1,11 +1,11 @@
 
 import { ChartOfAccount, Party, PriceList, PriceListItem, Product } from '../types';
 
-const MANAGEMENT_API_BASE = 'http://127.0.0.1:8000/api/management';
-const INVENTORY_API_BASE = 'http://127.0.0.1:8000/api/inventory';
-const SALE_API_BASE = 'http://127.0.0.1:8000/api/sale';
-const VOUCHER_API_BASE = 'http://127.0.0.1:8000/api/voucher';
-const PRICING_API_BASE = 'http://127.0.0.1:8000/api/pricing';
+const MANAGEMENT_API_BASE = 'http://127.0.0.1:8000/management';
+const INVENTORY_API_BASE = 'http://127.0.0.1:8000/inventory';
+const SALE_API_BASE = 'http://127.0.0.1:8000/sales';
+const VOUCHER_API_BASE = 'http://127.0.0.1:8000/voucher';
+const PRICING_API_BASE = 'http://127.0.0.1:8000/pricing';
 
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {

--- a/erp/urls.py
+++ b/erp/urls.py
@@ -17,7 +17,6 @@ Including another URLconf
 from django.contrib import admin
 
 from django.urls import include, path
-from voucher.views import customer_ledger
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
@@ -34,8 +33,7 @@ urlpatterns = [
 
 
     path('inventory/', include('inventory.urls')),
-
-    path('financials/ledger/customer/<int:party_id>/', customer_ledger, name='customer_ledger'),
+    path('voucher/', include('voucher.urls')),
 
     path('crm/', include('crm.urls')),
     path('tasks/', include('task.urls')),

--- a/voucher/serializers.py
+++ b/voucher/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from .models import ChartOfAccount
+
+
+class ChartOfAccountSerializer(serializers.ModelSerializer):
+    accountType = serializers.CharField(source="account_type.name")
+    parentId = serializers.IntegerField(source="parent_account_id", allow_null=True)
+    isActive = serializers.BooleanField(source="is_active")
+
+    class Meta:
+        model = ChartOfAccount
+        fields = ["id", "name", "code", "accountType", "parentId", "isActive"]

--- a/voucher/urls.py
+++ b/voucher/urls.py
@@ -1,0 +1,12 @@
+from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+
+from .views import ChartOfAccountViewSet, customer_ledger
+
+router = DefaultRouter()
+router.register(r'accounts', ChartOfAccountViewSet, basename='account')
+
+urlpatterns = [
+    path('ledger/customer/<int:party_id>/', customer_ledger, name='customer_ledger'),
+    path('', include(router.urls)),
+]

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -3,11 +3,13 @@
 from decimal import Decimal
 
 from django.shortcuts import get_object_or_404
+from rest_framework import permissions, viewsets
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from inventory.models import Party
-from .models import VoucherEntry
+from .models import VoucherEntry, ChartOfAccount
+from .serializers import ChartOfAccountSerializer
 
 
 @api_view(["GET"])
@@ -45,3 +47,9 @@ def customer_ledger(request, party_id):
         )
 
     return Response({"party": party.id, "party_name": party.name, "ledger": ledger})
+
+
+class ChartOfAccountViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = ChartOfAccount.objects.all()
+    serializer_class = ChartOfAccountSerializer
+    permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary
- update frontend management service to use real /inventory, /sales, /voucher, and /pricing API bases
- expose Chart of Account list via new voucher API endpoint
- include voucher URLs in project routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `python manage.py test` *(fails: table sale_saleinvoice has no column named customer_id)*

------
https://chatgpt.com/codex/tasks/task_e_68a0859e2ac88329b57402d514f42878