### PR TITLE
Add PasswordResetCode model and migration

### DIFF
--- a/user/migrations/0002_passwordresetcode.py
+++ b/user/migrations/0002_passwordresetcode.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('user', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PasswordResetCode',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('code', models.CharField(max_length=6)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('expires_at', models.DateTimeField()),
+                ('user', models.ForeignKey(on_delete=models.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/user/models.py
+++ b/user/models.py
@@ -1,6 +1,7 @@
 # accounts/models.py
 from django.contrib.auth.models import AbstractUser,BaseUserManager
 from django.db import models
+from django.utils import timezone
 
 
 
@@ -44,3 +45,16 @@ class CustomUser(AbstractUser):
     objects = CustomUserManager()
     def __str__(self):
         return f"{self.email} ({self.role})"
+
+
+class PasswordResetCode(models.Model):
+    user = models.ForeignKey(CustomUser, on_delete=models.CASCADE)
+    code = models.CharField(max_length=6)
+    created_at = models.DateTimeField(auto_now_add=True)
+    expires_at = models.DateTimeField()
+
+    def is_expired(self):
+        return timezone.now() >= self.expires_at
+
+    def __str__(self):
+        return f"{self.user.email} - {self.code}"


### PR DESCRIPTION
## Summary
- add PasswordResetCode model with expiry check for users
- include migration enabling storage of reset codes

## Testing
- `python manage.py makemigrations user` *(fails: purchaseinvoice field requires a default; migration created manually)*
- `python manage.py migrate user`
- `python manage.py test user`


------
https://chatgpt.com/codex/tasks/task_e_68a08b1e58b08329949fb1eed20a7031