### PR TITLE
Add password reset helpers with descriptive error handling

### DIFF
--- a/Frontend-PWD/services/auth.ts
+++ b/Frontend-PWD/services/auth.ts
@@ -11,7 +11,8 @@ export async function login(username: string, password: string): Promise<User> {
   });
 
   if (!response.ok) {
-    throw new Error('Login failed');
+    const errorText = await response.text();
+    throw new Error(errorText || 'Login failed');
   }
 
   const data = await response.json();
@@ -28,5 +29,45 @@ export function logout(): void {
 export function getCurrentUser(): User | null {
   const stored = localStorage.getItem(USER_KEY);
   return stored ? (JSON.parse(stored) as User) : null;
+}
+
+export async function requestPasswordReset(email: string): Promise<void> {
+  const response = await fetch(
+    `${baseUrl}/api/user/auth/reset-password/request/`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || 'Password reset request failed');
+  }
+}
+
+export async function confirmPasswordReset(
+  email: string,
+  code: string,
+  newPassword: string
+): Promise<void> {
+  const response = await fetch(
+    `${baseUrl}/api/user/auth/reset-password/confirm/`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email,
+        code,
+        new_password: newPassword,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || 'Password reset confirmation failed');
+  }
 }
 


### PR DESCRIPTION
## Summary
- add `requestPasswordReset` and `confirmPasswordReset` helpers in auth service
- improve login, reset request, and reset confirm error handling to surface server messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a08b4690048329ae84482fb4029523