### PR TITLE
Refactor SaleInvoice monetary fields

### DIFF
--- a/sale/forms.py
+++ b/sale/forms.py
@@ -17,11 +17,9 @@ class SaleInvoiceForm(forms.ModelForm):
             'warehouse',
             'salesman',
 
-           
             'total_amount',
             'discount',
             'tax',
-            'grand_total',
             'payment_method',
             'paid_amount',
             'status',
@@ -32,11 +30,7 @@ class SaleInvoiceForm(forms.ModelForm):
         total = cleaned_data.get('total_amount') or 0
         discount = cleaned_data.get('discount') or 0
         tax = cleaned_data.get('tax') or 0
-        grand_total = cleaned_data.get('grand_total') or 0
-        expected_grand_total = total - discount + tax
-        if grand_total != expected_grand_total:
-            self.add_error('grand_total', 'Grand total must equal total minus discount plus tax.')
-
+        grand_total = total - discount + tax
         paid = cleaned_data.get('paid_amount') or 0
         if paid > grand_total:
             self.add_error('paid_amount', 'Paid amount cannot exceed grand total.')

--- a/sale/serializers.py
+++ b/sale/serializers.py
@@ -55,8 +55,8 @@ class SaleInvoiceSerializer(serializers.ModelSerializer):
             "sub_total",
             "discount",
             "tax",
-            "grand_total",
             "paid_amount",
+            "grand_total",
             "net_amount",
             "payment_method",
             "status",
@@ -64,6 +64,7 @@ class SaleInvoiceSerializer(serializers.ModelSerializer):
             "items",
             "recovery_logs",
         ]
+        read_only_fields = ("grand_total", "net_amount")
 
     def create(self, validated_data):
         items_data = validated_data.pop("items", [])
@@ -76,13 +77,7 @@ class SaleInvoiceSerializer(serializers.ModelSerializer):
         total = data.get("sub_total") or 0
         discount = data.get("discount") or 0
         tax = data.get("tax") or 0
-        grand_total = data.get("grand_total") or 0
-        expected_grand_total = total - discount + tax
-        if grand_total != expected_grand_total:
-            raise serializers.ValidationError(
-                {"grand_total": "Grand total must equal sub total minus discount plus tax."}
-            )
-
+        grand_total = total - discount + tax
         paid = data.get("paid_amount") or 0
         if paid > grand_total:
             raise serializers.ValidationError(

--- a/sale/tests.py
+++ b/sale/tests.py
@@ -1,4 +1,5 @@
 from datetime import date
+from decimal import Decimal
 
 from django.urls import reverse
 from django.contrib.auth import get_user_model
@@ -76,13 +77,13 @@ class SaleInvoiceVoucherLinkTest(APITestCase):
             sub_total=10,
             discount=0,
             tax=0,
-            grand_total=10,
             paid_amount=10,
-            net_amount=10,
             payment_method="Cash",
             status="Paid",
         )
         self.assertIsNotNone(invoice.voucher)
+        self.assertEqual(invoice.grand_total, Decimal("10"))
+        self.assertEqual(invoice.net_amount, Decimal("0"))
 
     def test_status_action_updates_status_and_delivery_man(self):
         invoice = SaleInvoice.objects.create(
@@ -94,9 +95,6 @@ class SaleInvoiceVoucherLinkTest(APITestCase):
             sub_total=10,
             discount=0,
             tax=0,
-            grand_total=10,
-            paid_amount=0,
-            net_amount=10,
             payment_method="Cash",
             status="Pending",
         )


### PR DESCRIPTION
## Summary
- clean up duplicate tax field and compute totals inside `SaleInvoice.save`
- adjust invoice form and serializer for calculated totals
- update invoice tests to rely on automatic monetary calculations

## Testing
- `python manage.py test sale.tests.SaleInvoiceVoucherLinkTest.test_voucher_linked_on_creation` *(fails: OperationalError: table inventory_product has no column named image_1)*

------
https://chatgpt.com/codex/tasks/task_e_68a3661183f88329b328ed8ec5e74c92