### PR TITLE
Avoid recursive voucher saves and add tests

### DIFF
--- a/purchase/models.py
+++ b/purchase/models.py
@@ -45,7 +45,7 @@ class PurchaseInvoice(models.Model):
                     reason=f"Purchase Invoice {self.invoice_no}",
                 )
 
-        if not self.voucher:
+        if is_new and not self.voucher:
             voucher = create_voucher_for_transaction(
                 voucher_type_code="PUR",
                 date=self.date,
@@ -57,7 +57,7 @@ class PurchaseInvoice(models.Model):
                 branch=self.branch if hasattr(self, "branch") else None,
             )
             self.voucher = voucher
-            self.save(update_fields=["voucher"])
+            super().save(update_fields=["voucher"])
 
 
 class PurchaseInvoiceItem(models.Model):
@@ -94,19 +94,19 @@ class PurchaseReturn(models.Model):
                     batch_number=item.batch_number,
                     reason=f"Sale Return {self.return_no}"
                 )
-        if not self.voucher:
+        if is_new and not self.voucher:
             voucher = create_voucher_for_transaction(
-            voucher_type_code='PRN',  # Purchase Return
-            date=self.date,
-            amount=self.total_amount,
-            narration=f"Auto-voucher for Purchase Return {self.return_no}",
-            debit_account=self.supplier.chart_of_account,  # refund to supplier
-            credit_account=self.warehouse.purchase_account,  # reduce purchase
-            created_by=getattr(self, 'created_by', None),
-            branch=getattr(self, 'branch', None)
-             )
+                voucher_type_code='PRN',  # Purchase Return
+                date=self.date,
+                amount=self.total_amount,
+                narration=f"Auto-voucher for Purchase Return {self.return_no}",
+                debit_account=self.supplier.chart_of_account,  # refund to supplier
+                credit_account=self.warehouse.purchase_account,  # reduce purchase
+                created_by=getattr(self, 'created_by', None),
+                branch=getattr(self, 'branch', None)
+            )
             self.voucher = voucher
-            self.save(update_fields=['voucher'])
+            super().save(update_fields=['voucher'])
         
 
 class PurchaseReturnItem(models.Model):

--- a/purchase/tests.py
+++ b/purchase/tests.py
@@ -1,3 +1,66 @@
-from django.test import TestCase
+from datetime import date
 
-# Create your tests here.
+from django.test import SimpleTestCase
+from unittest.mock import patch
+
+from inventory.models import Party
+from setting.models import Branch, Warehouse
+from voucher.models import AccountType, ChartOfAccount, Voucher, VoucherType
+
+from .models import PurchaseInvoice, PurchaseReturn
+
+
+class PurchaseVoucherLinkTest(SimpleTestCase):
+    """Ensure voucher linking happens once without recursive saves."""
+
+    def _supplier_and_warehouse(self):
+        asset = AccountType(name="ASSET")
+        expense = AccountType(name="EXPENSE")
+        supplier_account = ChartOfAccount(name="SuppAcc", code="2000", account_type=asset)
+        purchase_account = ChartOfAccount(name="PurchAcc", code="5000", account_type=expense)
+
+        supplier = Party(
+            name="Supp", address="", phone="", party_type="supplier", chart_of_account=supplier_account
+        )
+        warehouse = Warehouse(
+            name="W1", branch=Branch(name="B", address=""), default_purchase_account=purchase_account
+        )
+        warehouse.purchase_account = purchase_account
+        return supplier, warehouse
+
+    def test_purchase_invoice_voucher_link_no_recursion(self):
+        supplier, warehouse = self._supplier_and_warehouse()
+        invoice = PurchaseInvoice(
+            invoice_no="PI-001", date=date.today(), total_amount=100, grand_total=100, supplier=supplier, warehouse=warehouse
+        )
+        dummy_voucher = Voucher(
+            voucher_type=VoucherType(code="X", name="X"), date=date.today(), amount=0
+        )
+        with patch("purchase.models.create_voucher_for_transaction", return_value=dummy_voucher):
+            with patch("django.db.models.Model.save", return_value=None):
+                dummy_manager = type("M", (), {"all": lambda self: []})()
+                with patch.object(PurchaseInvoice, "items", dummy_manager):
+                    with patch.object(
+                        PurchaseInvoice, "save", wraps=PurchaseInvoice.save, autospec=True
+                    ) as mock_save:
+                        invoice.save()
+                        self.assertEqual(mock_save.call_count, 1)
+        self.assertIs(invoice.voucher, dummy_voucher)
+
+    def test_purchase_return_voucher_link_no_recursion(self):
+        supplier, warehouse = self._supplier_and_warehouse()
+        pr = PurchaseReturn(return_no="PR-001", date=date.today(), total_amount=50, supplier=supplier, warehouse=warehouse)
+        dummy_voucher = Voucher(
+            voucher_type=VoucherType(code="Y", name="Y"), date=date.today(), amount=0
+        )
+        with patch("purchase.models.create_voucher_for_transaction", return_value=dummy_voucher):
+            with patch("django.db.models.Model.save", return_value=None):
+                dummy_manager = type("M", (), {"all": lambda self: []})()
+                with patch.object(PurchaseReturn, "items", dummy_manager):
+                    with patch.object(
+                        PurchaseReturn, "save", wraps=PurchaseReturn.save, autospec=True
+                    ) as mock_save:
+                        pr.save()
+                        self.assertEqual(mock_save.call_count, 1)
+        self.assertIs(pr.voucher, dummy_voucher)
+

--- a/sale/models.py
+++ b/sale/models.py
@@ -120,19 +120,20 @@ class SaleReturn(models.Model):
                     batch_number=item.batch_number,
                     reason=f"Sale Return {self.return_no}"
                 )
-        if not self.voucher:
+
+        if is_new and not self.voucher:
             voucher = create_voucher_for_transaction(
-            voucher_type_code='SRN',
-            date=self.date,
-            amount=self.total_amount,
-            narration=f"Auto-voucher for Sale Return {self.return_no}",
-            debit_account=self.warehouse.default_sales_account,        # reverse sale
-            credit_account=self.customer.chart_of_account,     # reduce receivable
-            created_by=getattr(self, 'created_by', None),
-            branch=getattr(self, 'branch', None)
-        )
-        self.voucher = voucher
-        self.save(update_fields=['voucher'])
+                voucher_type_code='SRN',
+                date=self.date,
+                amount=self.total_amount,
+                narration=f"Auto-voucher for Sale Return {self.return_no}",
+                debit_account=self.warehouse.default_sales_account,        # reverse sale
+                credit_account=self.customer.chart_of_account,     # reduce receivable
+                created_by=getattr(self, 'created_by', None),
+                branch=getattr(self, 'branch', None)
+            )
+            self.voucher = voucher
+            super().save(update_fields=['voucher'])
 
 class SaleReturnItem(models.Model):
     return_invoice = models.ForeignKey(SaleReturn, related_name='items', on_delete=models.CASCADE)

--- a/sale/tests.py
+++ b/sale/tests.py
@@ -3,6 +3,8 @@ from datetime import date
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
+from django.test import TestCase, SimpleTestCase
+from unittest.mock import patch
 
 from inventory.models import Party, Product
 from setting.models import (
@@ -14,9 +16,9 @@ from setting.models import (
     Group,
     Warehouse,
 )
-from voucher.models import AccountType, ChartOfAccount, VoucherType
+from voucher.models import AccountType, ChartOfAccount, VoucherType, Voucher
 from hr.models import Employee
-from .models import SaleInvoice
+from .models import SaleInvoice, SaleReturn
 
 User = get_user_model()
 
@@ -109,3 +111,27 @@ class SaleInvoiceVoucherLinkTest(APITestCase):
         self.assertEqual(patch_resp.status_code, 200, patch_resp.data)
         self.assertEqual(patch_resp.data["status"], "Paid")
         self.assertEqual(patch_resp.data["delivery_man_id"], employee.id)
+
+
+class SaleReturnVoucherLinkTest(SimpleTestCase):
+    """Verify voucher linkage for sale returns without recursive save calls."""
+
+    def test_sale_return_links_voucher_without_recursion(self):
+        asset = AccountType(name="ASSET")
+        income = AccountType(name="INCOME")
+        customer_account = ChartOfAccount(name="CustAcc", code="1000", account_type=asset)
+        sales_account = ChartOfAccount(name="Sales", code="4000", account_type=income)
+        customer = Party(name="Cust", address="", phone="", party_type="customer", chart_of_account=customer_account)
+        warehouse = Warehouse(name="W1", branch=Branch(name="B", address=""), default_sales_account=sales_account)
+        sr = SaleReturn(return_no="SR-001", date=date.today(), total_amount=10, customer=customer, warehouse=warehouse)
+        dummy_voucher = Voucher(
+            voucher_type=VoucherType(code="SR", name="SR"), date=date.today(), amount=0
+        )
+        with patch("sale.models.create_voucher_for_transaction", return_value=dummy_voucher):
+            with patch("django.db.models.Model.save", return_value=None):
+                dummy_manager = type("M", (), {"all": lambda self: []})()
+                with patch.object(SaleReturn, "items", dummy_manager):
+                    with patch.object(SaleReturn, "save", wraps=SaleReturn.save, autospec=True) as mock_save:
+                        sr.save()
+                        self.assertEqual(mock_save.call_count, 1)
+        self.assertIs(sr.voucher, dummy_voucher)


### PR DESCRIPTION
## Summary
- prevent recursive save calls in PurchaseInvoice, PurchaseReturn, and SaleReturn by delegating to `super().save` and guarding voucher creation with `is_new`
- add unit tests ensuring vouchers link once and save methods are non-recursive

## Testing
- `python manage.py test inventory.tests.InventoryLevelsAPITest` *(fails: OperationalError: table inventory_product has no column named image_1)*
- `python manage.py test purchase.tests.PurchaseVoucherLinkTest sale.tests.SaleReturnVoucherLinkTest`


------
https://chatgpt.com/codex/tasks/task_e_68a366160f6c83299cba5c6db2f09fa7