### PR TITLE
Add voucher creation to investor transactions

### DIFF
--- a/investor/migrations/0002_transactiontype_choices.py
+++ b/investor/migrations/0002_transactiontype_choices.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('investor', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='investortransaction',
+            name='transaction_type',
+            field=models.CharField(max_length=10, choices=[('investment', 'Investment'), ('payout', 'Payout'), ('profit', 'Profit')]),
+        ),
+    ]

--- a/investor/models.py
+++ b/investor/models.py
@@ -1,12 +1,70 @@
 from django.db import models
 
+from voucher.models import ChartOfAccount
+from utils.voucher import create_voucher_for_transaction
+
 
 class InvestorTransaction(models.Model):
-    investor = models.ForeignKey('inventory.Party', on_delete=models.CASCADE,related_name="inventor_transaction", limit_choices_to={'party_type': 'investor'})
+    """Represents money movements between the company and an investor.
+
+    When a transaction is saved a corresponding accounting voucher is
+    automatically generated.  The debit and credit accounts for the voucher
+    depend on the ``transaction_type``.
+    """
+
+    TRANSACTION_TYPES = [
+        ("investment", "Investment"),
+        ("payout", "Payout"),
+        ("profit", "Profit"),
+    ]
+
+    investor = models.ForeignKey(
+        "inventory.Party",
+        on_delete=models.CASCADE,
+        related_name="inventor_transaction",
+        limit_choices_to={"party_type": "investor"},
+    )
     amount = models.DecimalField(max_digits=10, decimal_places=2)
-    transaction_type = models.CharField(max_length=10, choices=[('IN', 'In'), ('OUT', 'Out')])
+    transaction_type = models.CharField(max_length=10, choices=TRANSACTION_TYPES)
     date = models.DateField()
     description = models.TextField(blank=True)
+
+    # Mapping of transaction type to debit/credit accounts.  ``None`` means the
+    # investor's own ledger account should be used for that side of the entry.
+    LEDGER_MAP = {
+        "investment": {"debit": "CASH", "credit": None},
+        "payout": {"debit": None, "credit": "CASH"},
+        "profit": {"debit": "PROFIT", "credit": None},
+    }
+
+    def save(self, *args, **kwargs):
+        is_new = self.pk is None
+        super().save(*args, **kwargs)
+
+        if is_new:
+            mapping = self.LEDGER_MAP.get(self.transaction_type)
+            if not mapping:
+                return
+
+            debit_account = (
+                self.investor.chart_of_account
+                if mapping["debit"] is None
+                else ChartOfAccount.objects.get(code=mapping["debit"])
+            )
+            credit_account = (
+                self.investor.chart_of_account
+                if mapping["credit"] is None
+                else ChartOfAccount.objects.get(code=mapping["credit"])
+            )
+
+            create_voucher_for_transaction(
+                voucher_type_code="INV",
+                date=self.date,
+                amount=self.amount,
+                narration=self.description or f"{self.transaction_type.title()} transaction",
+                debit_account=debit_account,
+                credit_account=credit_account,
+            )
 
     def __str__(self):
         return f"{self.investor.name} - {self.amount}"

--- a/investor/tests.py
+++ b/investor/tests.py
@@ -1,0 +1,80 @@
+from datetime import date
+
+from django.test import TestCase
+
+from inventory.models import Party
+from voucher.models import AccountType, ChartOfAccount, Voucher, VoucherType
+
+from .models import InvestorTransaction
+
+
+class InvestorTransactionVoucherTests(TestCase):
+    """Ensure vouchers are created with correct ledger entries."""
+
+    def setUp(self):
+        asset = AccountType.objects.create(name="ASSET")
+        liability = AccountType.objects.create(name="LIABILITY")
+        expense = AccountType.objects.create(name="EXPENSE")
+
+        self.cash_account = ChartOfAccount.objects.create(
+            name="Cash", code="CASH", account_type=asset
+        )
+        self.profit_account = ChartOfAccount.objects.create(
+            name="Profit Distribution", code="PROFIT", account_type=expense
+        )
+        self.investor_account = ChartOfAccount.objects.create(
+            name="Investor Ledger", code="INVESTOR", account_type=liability
+        )
+
+        self.investor = Party.objects.create(
+            name="Investor A",
+            address="addr",
+            phone="123",
+            party_type="investor",
+            chart_of_account=self.investor_account,
+        )
+
+        VoucherType.objects.create(name="Investor Txn", code="INV")
+
+    def _get_entries(self):
+        voucher = Voucher.objects.latest("id")
+        entries = {e.account.code: (e.debit, e.credit) for e in voucher.entries.all()}
+        return voucher, entries
+
+    def test_investment_creates_voucher(self):
+        InvestorTransaction.objects.create(
+            investor=self.investor,
+            amount=100,
+            transaction_type="investment",
+            date=date.today(),
+        )
+
+        voucher, entries = self._get_entries()
+        self.assertEqual(voucher.amount, 100)
+        self.assertEqual(entries["CASH"], (100, 0))
+        self.assertEqual(entries["INVESTOR"], (0, 100))
+
+    def test_payout_creates_voucher(self):
+        InvestorTransaction.objects.create(
+            investor=self.investor,
+            amount=50,
+            transaction_type="payout",
+            date=date.today(),
+        )
+
+        voucher, entries = self._get_entries()
+        self.assertEqual(entries["INVESTOR"], (50, 0))
+        self.assertEqual(entries["CASH"], (0, 50))
+
+    def test_profit_creates_voucher(self):
+        InvestorTransaction.objects.create(
+            investor=self.investor,
+            amount=75,
+            transaction_type="profit",
+            date=date.today(),
+        )
+
+        voucher, entries = self._get_entries()
+        self.assertEqual(entries["PROFIT"], (75, 0))
+        self.assertEqual(entries["INVESTOR"], (0, 75))
+


### PR DESCRIPTION
## Summary
- map investor transaction types to ledger accounts
- auto-create voucher entries when saving investor transactions
- test voucher entries for investment, payout, and profit transactions

## Testing
- `python manage.py test investor.tests`
- `python manage.py test` *(fails: table inventory_product has no column named image_1)*


------
https://chatgpt.com/codex/tasks/task_e_68a36619c90c832997e7af1d2a582393