### PR TITLE
Generate vouchers for payroll slips

### DIFF
--- a/hr/migrations/0003_payroll_voucher.py
+++ b/hr/migrations/0003_payroll_voucher.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('voucher', '0001_initial'),
+        ('hr', '0002_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='payrollslip',
+            name='voucher',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='voucher.voucher'),
+        ),
+    ]

--- a/hr/models.py
+++ b/hr/models.py
@@ -2,6 +2,10 @@ from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from user.models import CustomUser
+from decimal import Decimal
+from utils.voucher import create_voucher_for_transaction
+from voucher.models import VoucherType
+from setting.models import Company
 
 
 class EmployeeRole(models.TextChoices):
@@ -146,8 +150,33 @@ class PayrollSlip(models.Model):
     leaves_paid = models.PositiveIntegerField(default=0)
     deductions = models.DecimalField(max_digits=10, decimal_places=2, default=0)
     net_salary = models.DecimalField(max_digits=10, decimal_places=2)
+    voucher = models.ForeignKey('voucher.Voucher', on_delete=models.SET_NULL, null=True, blank=True)
 
     created_on = models.DateTimeField(auto_now_add=True)
+
+    def save(self, *args, **kwargs):
+        total_days = self.present_days + self.absent_days
+        per_day = (self.base_salary / total_days) if total_days else Decimal('0')
+        unpaid_absent = max(self.absent_days - self.leaves_paid, 0)
+        self.net_salary = self.base_salary - (per_day * unpaid_absent) - self.deductions
+        super().save(*args, **kwargs)
+
+        if not self.voucher:
+            VoucherType.objects.get_or_create(code="PAY", name="Payroll")
+            company = Company.objects.first()
+            if company and company.payroll_expense_account and company.payroll_payment_account:
+                voucher = create_voucher_for_transaction(
+                    voucher_type_code="PAY",
+                    date=self.month,
+                    amount=self.net_salary,
+                    narration=f"Payroll for {self.employee.name} - {self.month.strftime('%B %Y')}",
+                    debit_account=company.payroll_expense_account,
+                    credit_account=company.payroll_payment_account,
+                    created_by=getattr(self, 'created_by', None),
+                    branch=getattr(self, 'branch', None),
+                )
+                self.voucher = voucher
+                super().save(update_fields=['voucher'])
 
     def __str__(self):
         return f"{self.employee.name} - {self.month.strftime('%B %Y')}"

--- a/hr/serializers.py
+++ b/hr/serializers.py
@@ -156,5 +156,6 @@ class PayrollSlipSerializer(serializers.ModelSerializer):
             "leaves_paid",
             "deductions",
             "net_salary",
+            "voucher",
             "created_on",
         ]

--- a/hr/tests.py
+++ b/hr/tests.py
@@ -1,9 +1,13 @@
 from datetime import date
+from datetime import date
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
-from .models import Employee, LeaveRequest
+from setting.models import Company
+from voucher.models import AccountType, ChartOfAccount
+from .models import Employee, LeaveRequest, PayrollSlip
 from .views import LeaveRequestViewSet
 
 
@@ -26,4 +30,45 @@ class LeaveRequestApprovalTests(SimpleTestCase):
             viewset._deduct_balance_if_approved(request, previous_status="PENDING")
 
         mock_balance.deduct_leave.assert_called_once_with("ANNUAL", 3)
+
+
+class PayrollSlipVoucherTests(TestCase):
+    def setUp(self):
+        expense = AccountType.objects.create(name="EXPENSE")
+        asset = AccountType.objects.create(name="ASSET")
+        self.expense_account = ChartOfAccount.objects.create(
+            name="Salaries", code="5002", account_type=expense
+        )
+        self.cash_account = ChartOfAccount.objects.create(
+            name="Cash", code="1001", account_type=asset
+        )
+        Company.objects.create(
+            name="C1",
+            payroll_expense_account=self.expense_account,
+            payroll_payment_account=self.cash_account,
+        )
+        self.employee = Employee.objects.create(name="John", phone="123")
+
+    def test_voucher_linked_and_net_salary_calculated(self):
+        slip = PayrollSlip.objects.create(
+            employee=self.employee,
+            month=date(2024, 1, 1),
+            base_salary=Decimal("3000"),
+            present_days=28,
+            absent_days=2,
+            leaves_paid=1,
+            deductions=Decimal("100"),
+            net_salary=0,
+        )
+        slip.refresh_from_db()
+        self.assertEqual(slip.net_salary, Decimal("2800"))
+        self.assertIsNotNone(slip.voucher)
+        voucher = slip.voucher
+        entries = list(voucher.entries.all().order_by("id"))
+        self.assertEqual(voucher.amount, Decimal("2800"))
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0].account, self.expense_account)
+        self.assertEqual(entries[0].debit, Decimal("2800"))
+        self.assertEqual(entries[1].account, self.cash_account)
+        self.assertEqual(entries[1].credit, Decimal("2800"))
 

--- a/setting/migrations/0003_payroll_accounts.py
+++ b/setting/migrations/0003_payroll_accounts.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('voucher', '0001_initial'),
+        ('setting', '0002_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='company',
+            name='payroll_expense_account',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='payroll_expense_company', to='voucher.chartofaccount'),
+        ),
+        migrations.AddField(
+            model_name='company',
+            name='payroll_payment_account',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='payroll_payment_company', to='voucher.chartofaccount'),
+        ),
+    ]

--- a/setting/models.py
+++ b/setting/models.py
@@ -14,6 +14,20 @@ class Area(models.Model):
 
 class Company(models.Model):
     name = models.CharField(max_length=100)
+    payroll_expense_account = models.ForeignKey(
+        'voucher.ChartOfAccount',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='payroll_expense_company'
+    )
+    payroll_payment_account = models.ForeignKey(
+        'voucher.ChartOfAccount',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='payroll_payment_company'
+    )
 
 class Group(models.Model):
     name = models.CharField(max_length=100)

--- a/voucher/management/commands/init_accounting.py
+++ b/voucher/management/commands/init_accounting.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from voucher.models import AccountType, ChartOfAccount
 from inventory.models import Party
-from setting.models import Warehouse
+from setting.models import Warehouse, Company
 from django.db import transaction
 
 DEFAULT_COA = {
@@ -65,5 +65,12 @@ class Command(BaseCommand):
             if not wh.default_purchase_account:
                 wh.default_purchase_account = ChartOfAccount.objects.get(code="5001")
             wh.save()
+
+        for comp in Company.objects.all():
+            if not comp.payroll_expense_account:
+                comp.payroll_expense_account = ChartOfAccount.objects.get(code="5002")
+            if not comp.payroll_payment_account:
+                comp.payroll_payment_account = ChartOfAccount.objects.get(code="1001")
+            comp.save()
 
         self.stdout.write(self.style.SUCCESS("✅ Accounting initialization complete."))


### PR DESCRIPTION
## Summary
- create payroll vouchers in `PayrollSlip.save`
- add company-level defaults for payroll expense and payment accounts
- ensure init command sets up payroll accounts
- test net salary and voucher linkage

## Testing
- `python manage.py test` *(fails: table inventory_product has no column named image_1)*
- `python manage.py test hr.tests.PayrollSlipVoucherTests --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_68a3661a4bb4832997fbd0ee670b103d