### PR TITLE
Add reports URL routing and dashboard view

### DIFF
--- a/erp/urls.py
+++ b/erp/urls.py
@@ -42,6 +42,7 @@ urlpatterns = [
     path('pricing/', include('pricing.urls')),
     path('expenses/', include('expense.urls')),
     path('investor/', include('investor.urls')),
+    path('reports/', include('report.urls')),
     path('sync/', include('syncqueue.urls')),
 
     path('hr/', include('hr.urls')),

--- a/report/urls.py
+++ b/report/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.report_dashboard, name='report_dashboard'),
+]

--- a/report/views.py
+++ b/report/views.py
@@ -1,3 +1,7 @@
 from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
 
-# Create your views here.
+
+@require_http_methods(["GET"])
+def report_dashboard(request):
+    return render(request, 'report/dashboard.html')

--- a/templates/report/dashboard.html
+++ b/templates/report/dashboard.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Reports Dashboard</h1>
+<p>Report overview goes here.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add URL configuration for reports and link into main project URLs
- Implement simple reports dashboard view with template

## Testing
- `python manage.py test` *(fails: Conflicting migrations detected; multiple leaf nodes in the migration graph: (0003_add_cash_accounts, 0003_payroll_accounts in setting))*
- `python manage.py runserver 0.0.0.0:8000` & `curl -i http://127.0.0.1:8000/reports/`


------
https://chatgpt.com/codex/tasks/task_e_68a37936dc748329871191dbb62b47eb