### PR TITLE
Link vouchers to payment schedules

### DIFF
--- a/finance/migrations/0002_paymentschedule_voucher.py
+++ b/finance/migrations/0002_paymentschedule_voucher.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('voucher', '0002_add_installment_vouchertypes'),
+        ('finance', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='paymentschedule',
+            name='voucher',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='voucher.voucher'),
+        ),
+    ]
+

--- a/finance/models.py
+++ b/finance/models.py
@@ -36,6 +36,12 @@ class PaymentSchedule(models.Model):
     due_date = models.DateField()
     amount = models.DecimalField(max_digits=12, decimal_places=2)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="Pending")
+    voucher = models.ForeignKey(
+        'voucher.Voucher',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
 
     def __str__(self):  # pragma: no cover - display helper
         invoice = self.purchase_invoice or self.sale_invoice

--- a/finance/serializers.py
+++ b/finance/serializers.py
@@ -10,6 +10,21 @@ class PaymentTermSerializer(serializers.ModelSerializer):
 
 
 class PaymentScheduleSerializer(serializers.ModelSerializer):
+    voucher = serializers.SerializerMethodField(read_only=True)
+
+    def get_voucher(self, obj):
+        if obj.voucher:
+            return {
+                "id": obj.voucher.id,
+                "voucher_type": obj.voucher.voucher_type.code,
+                "date": obj.voucher.date,
+                "amount": obj.voucher.amount,
+                "narration": obj.voucher.narration,
+                "status": obj.voucher.status,
+            }
+        return None
+
     class Meta:
         model = PaymentSchedule
         fields = '__all__'
+        read_only_fields = ('voucher',)

--- a/finance/views.py
+++ b/finance/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from .models import PaymentSchedule
 from .serializers import PaymentScheduleSerializer
+from utils.voucher import create_voucher_for_transaction
 
 
 class PaymentScheduleViewSet(viewsets.ModelViewSet):
@@ -22,4 +23,30 @@ class PaymentScheduleViewSet(viewsets.ModelViewSet):
                 if invoice.paid_amount >= invoice.grand_total:
                     invoice.status = "Paid"
                 invoice.save(update_fields=["paid_amount", "status"])
-        return Response({"status": "paid"})
+
+                if schedule.purchase_invoice:
+                    voucher = create_voucher_for_transaction(
+                        voucher_type_code="PIN",
+                        date=invoice.date,
+                        amount=schedule.amount,
+                        narration=f"Installment payment for Purchase Invoice {invoice.invoice_no}",
+                        debit_account=invoice.supplier.chart_of_account,
+                        credit_account=invoice.warehouse.default_cash_account or invoice.warehouse.default_bank_account,
+                        created_by=getattr(invoice, "created_by", None),
+                        branch=getattr(invoice, "branch", None),
+                    )
+                else:
+                    voucher = create_voucher_for_transaction(
+                        voucher_type_code="SIN",
+                        date=invoice.date,
+                        amount=schedule.amount,
+                        narration=f"Installment payment for Sale Invoice {invoice.invoice_no}",
+                        debit_account=invoice.warehouse.default_cash_account or invoice.warehouse.default_bank_account,
+                        credit_account=invoice.customer.chart_of_account,
+                        created_by=getattr(invoice, "created_by", None),
+                        branch=getattr(invoice, "branch", None),
+                    )
+                schedule.voucher = voucher
+                schedule.save(update_fields=["voucher"])
+        serializer = self.get_serializer(schedule)
+        return Response(serializer.data)

--- a/voucher/migrations/0002_add_installment_vouchertypes.py
+++ b/voucher/migrations/0002_add_installment_vouchertypes.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def create_installment_voucher_types(apps, schema_editor):
+    VoucherType = apps.get_model('voucher', 'VoucherType')
+    VoucherType.objects.get_or_create(
+        code='PIN', defaults={'name': 'Purchase Installment'}
+    )
+    VoucherType.objects.get_or_create(
+        code='SIN', defaults={'name': 'Sale Installment'}
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('voucher', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_installment_voucher_types, migrations.RunPython.noop),
+    ]
+


### PR DESCRIPTION
## Summary
- add voucher relation to `PaymentSchedule`
- expose linked voucher data in `PaymentScheduleSerializer`
- generate vouchers when marking schedules paid and seed installment voucher types

## Testing
- `python manage.py test` *(fails: SyntaxError in purchase.tests and missing DB columns)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e74714508329aa4ee5c2a9100153