### PR TITLE
Add journal voucher API

### DIFF
--- a/voucher/migrations/0003_add_journal_vouchertype.py
+++ b/voucher/migrations/0003_add_journal_vouchertype.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def create_journal_voucher_type(apps, schema_editor):
+    """Ensure a voucher type exists for general journal entries."""
+    VoucherType = apps.get_model("voucher", "VoucherType")
+    VoucherType.objects.get_or_create(
+        code="JV", defaults={"name": "Journal"}
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("voucher", "0002_add_installment_vouchertypes"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_journal_voucher_type, migrations.RunPython.noop
+        ),
+    ]
+

--- a/voucher/serializers.py
+++ b/voucher/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import ChartOfAccount
+from .models import ChartOfAccount, Voucher, VoucherEntry, VoucherType
 
 
 class ChartOfAccountSerializer(serializers.ModelSerializer):
@@ -11,3 +11,42 @@ class ChartOfAccountSerializer(serializers.ModelSerializer):
     class Meta:
         model = ChartOfAccount
         fields = ["id", "name", "code", "accountType", "parentId", "isActive"]
+
+
+class VoucherEntrySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = VoucherEntry
+        fields = ["account", "debit", "credit", "remarks"]
+
+
+class JournalVoucherSerializer(serializers.ModelSerializer):
+    entries = VoucherEntrySerializer(many=True)
+
+    class Meta:
+        model = Voucher
+        fields = ["id", "date", "narration", "branch", "entries"]
+        read_only_fields = ["id"]
+
+    def validate(self, attrs):
+        entries = attrs.get("entries", [])
+        debit_total = sum(e["debit"] for e in entries)
+        credit_total = sum(e["credit"] for e in entries)
+        if debit_total != credit_total:
+            raise serializers.ValidationError("Entries are not balanced")
+        attrs["amount"] = debit_total
+        return attrs
+
+    def create(self, validated_data):
+        entries_data = validated_data.pop("entries")
+        request = self.context.get("request")
+        created_by = request.user if request else None
+        voucher_type = VoucherType.objects.get(code=VoucherType.JOURNAL)
+        voucher = Voucher.create_with_entries(
+            voucher_type=voucher_type,
+            date=validated_data["date"],
+            narration=validated_data.get("narration", ""),
+            created_by=created_by,
+            branch=validated_data.get("branch"),
+            entries=entries_data,
+        )
+        return voucher

--- a/voucher/tests.py
+++ b/voucher/tests.py
@@ -1,3 +1,83 @@
-from django.test import TestCase
+from datetime import date
+from decimal import Decimal
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from voucher.models import AccountType, ChartOfAccount, Voucher, VoucherType
+from voucher.test_utils import assert_ledger_entries
+
+
+User = get_user_model()
+
+
+class JournalVoucherTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("user@example.com", "pass")
+        self.client.force_authenticate(self.user)
+
+        asset = AccountType.objects.create(name="ASSET")
+        income = AccountType.objects.create(name="INCOME")
+        self.cash = ChartOfAccount.objects.create(
+            name="Cash", code="CASH", account_type=asset
+        )
+        self.sales = ChartOfAccount.objects.create(
+            name="Sales", code="SALES", account_type=income
+        )
+
+        VoucherType.objects.get_or_create(
+            code=VoucherType.JOURNAL, defaults={"name": "Journal"}
+        )
+
+    def test_create_journal_voucher(self):
+        response = self.client.post(
+            "/voucher/journal/",
+            {
+                "date": date.today().isoformat(),
+                "narration": "Sale entry",
+                "entries": [
+                    {
+                        "account": self.cash.id,
+                        "debit": "100.00",
+                        "credit": "0",
+                        "remarks": "cash",
+                    },
+                    {
+                        "account": self.sales.id,
+                        "debit": "0",
+                        "credit": "100.00",
+                        "remarks": "sales",
+                    },
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        voucher = Voucher.objects.get(id=response.data["id"])
+        self.assertEqual(voucher.amount, Decimal("100.00"))
+        assert_ledger_entries(
+            self,
+            voucher,
+            [
+                (self.cash, Decimal("100.00"), 0),
+                (self.sales, 0, Decimal("100.00")),
+            ],
+        )
+
+    def test_reject_unbalanced_entries(self):
+        response = self.client.post(
+            "/voucher/journal/",
+            {
+                "date": date.today().isoformat(),
+                "narration": "Bad entry",
+                "entries": [
+                    {"account": self.cash.id, "debit": "100", "credit": "0"},
+                    {"account": self.sales.id, "debit": "0", "credit": "90"},
+                ],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+

--- a/voucher/urls.py
+++ b/voucher/urls.py
@@ -1,12 +1,17 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from .views import ChartOfAccountViewSet, customer_ledger
+from .views import (
+    ChartOfAccountViewSet,
+    JournalVoucherCreateAPIView,
+    customer_ledger,
+)
 
 router = DefaultRouter()
 router.register(r'accounts', ChartOfAccountViewSet, basename='account')
 
 urlpatterns = [
     path('ledger/customer/<int:party_id>/', customer_ledger, name='customer_ledger'),
+    path('journal/', JournalVoucherCreateAPIView.as_view(), name='journal_voucher_create'),
     path('', include(router.urls)),
 ]

--- a/voucher/views.py
+++ b/voucher/views.py
@@ -3,13 +3,13 @@
 from decimal import Decimal
 
 from django.shortcuts import get_object_or_404
-from rest_framework import permissions, viewsets
+from rest_framework import generics, permissions, viewsets
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from inventory.models import Party
 from .models import VoucherEntry, ChartOfAccount
-from .serializers import ChartOfAccountSerializer
+from .serializers import ChartOfAccountSerializer, JournalVoucherSerializer
 
 
 @api_view(["GET"])
@@ -52,4 +52,9 @@ def customer_ledger(request, party_id):
 class ChartOfAccountViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ChartOfAccount.objects.all()
     serializer_class = ChartOfAccountSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class JournalVoucherCreateAPIView(generics.CreateAPIView):
+    serializer_class = JournalVoucherSerializer
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary
- Add `VoucherType.JOURNAL` and helper to create vouchers with any number of balanced entries.
- Provide serializers and view to submit multi-line journal vouchers through `/voucher/journal/`.
- Seed default journal voucher type and cover with API tests.

## Testing
- `python manage.py test voucher.tests.JournalVoucherTests --verbosity 2`
- `python manage.py makemigrations voucher --check --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68a4f566d2e88329b8bb79cd59820dd8