### PR TITLE
Handle tax vouchers in sales and purchases

### DIFF
--- a/setting/constants.py
+++ b/setting/constants.py
@@ -1,0 +1,5 @@
+"""Application-wide accounting constants."""
+
+# Chart of account codes for tax-related accounts
+TAX_PAYABLE_ACCOUNT_CODE = "2100"  # Sales tax payable
+TAX_RECEIVABLE_ACCOUNT_CODE = "1300"  # Purchase tax receivable


### PR DESCRIPTION
## Summary
- create constants for tax payable and receivable chart codes
- build sale voucher entries splitting revenue and tax when tax is present
- build purchase voucher entries recognizing tax receivable
- add tests for sales and purchases verifying tax voucher lines

## Testing
- `python -m py_compile sale/tests.py purchase/tests.py`
- `python manage.py test sale.tests.SaleInvoiceVoucherLinkTest.test_cash_invoice_with_tax_posts_tax_payable -v 2` *(fails: Migration hr.0002_initial dependencies reference nonexistent parent node ('sale', '0001_initial'))*
- `python manage.py test purchase.tests.PurchaseVoucherTests.test_purchase_invoice_with_tax_posts_tax_receivable -v 2` *(fails: Migration hr.0002_initial dependencies reference nonexistent parent node ('sale', '0001_initial'))*

------
https://chatgpt.com/codex/tasks/task_e_68a5008058248329acddaef215366c6c