### PR TITLE
Add financial statement aggregation service and API

### DIFF
--- a/report/financial_statements.py
+++ b/report/financial_statements.py
@@ -1,0 +1,44 @@
+"""Utility helpers for financial statement reports.
+
+These services aggregate :class:`~voucher.models.VoucherEntry` balances by
+their related :class:`~voucher.models.AccountType` for a given period.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Dict
+
+from django.db.models import Sum
+
+from voucher.models import VoucherEntry
+
+
+def account_type_balances(*, start_date: date, end_date: date) -> Dict[str, Decimal]:
+    """Return net balances grouped by account type.
+
+    Balances are calculated as ``total_debit - total_credit`` for all voucher
+    entries whose parent voucher falls within ``start_date`` and ``end_date``
+    inclusive. The returned dictionary maps ``AccountType`` ``name`` values to
+    their computed totals.
+    """
+
+    entries = (
+        VoucherEntry.objects.filter(
+            voucher__date__gte=start_date, voucher__date__lte=end_date
+        )
+        .values("account__account_type__name")
+        .annotate(total_debit=Sum("debit"), total_credit=Sum("credit"))
+    )
+
+    totals: Dict[str, Decimal] = {}
+    for row in entries:
+        account_type = row["account__account_type__name"]
+        totals[account_type] = row["total_debit"] - row["total_credit"]
+
+    return totals
+
+
+__all__ = ["account_type_balances"]
+

--- a/report/tests.py
+++ b/report/tests.py
@@ -1,3 +1,73 @@
-from django.test import TestCase
+from datetime import date
+from decimal import Decimal
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from voucher.models import AccountType, ChartOfAccount, Voucher, VoucherType
+
+from .financial_statements import account_type_balances
+
+
+User = get_user_model()
+
+
+class FinancialStatementTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("user@example.com", "pass")
+
+        asset = AccountType.objects.create(name="ASSET")
+        liability = AccountType.objects.create(name="LIABILITY")
+
+        self.cash = ChartOfAccount.objects.create(
+            name="Cash", code="CASH", account_type=asset
+        )
+        self.loan = ChartOfAccount.objects.create(
+            name="Loan", code="LOAN", account_type=liability
+        )
+
+        voucher_type, _ = VoucherType.objects.get_or_create(
+            code=VoucherType.JOURNAL, defaults={"name": "Journal"}
+        )
+
+        # First voucher: cash debit 100, loan credit 100
+        Voucher.create_with_entries(
+            voucher_type=voucher_type,
+            date=date(2024, 1, 15),
+            narration="",
+            created_by=self.user,
+            entries=[
+                {"account": self.cash, "debit": Decimal("100"), "credit": Decimal("0")},
+                {"account": self.loan, "debit": Decimal("0"), "credit": Decimal("100")},
+            ],
+        )
+
+        # Second voucher: loan debit 30, cash credit 30
+        Voucher.create_with_entries(
+            voucher_type=voucher_type,
+            date=date(2024, 2, 1),
+            narration="",
+            created_by=self.user,
+            entries=[
+                {"account": self.loan, "debit": Decimal("30"), "credit": Decimal("0")},
+                {"account": self.cash, "debit": Decimal("0"), "credit": Decimal("30")},
+            ],
+        )
+
+    def test_account_type_balances_service(self):
+        totals = account_type_balances(
+            start_date=date(2024, 1, 1), end_date=date(2024, 12, 31)
+        )
+        self.assertEqual(totals["ASSET"], Decimal("70"))
+        self.assertEqual(totals["LIABILITY"], Decimal("-70"))
+
+    def test_financial_statement_view(self):
+        self.client.force_authenticate(self.user)
+        url = reverse("financial_statement")
+        response = self.client.get(url, {"year": 2024})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(Decimal(data["ASSET"]), Decimal("70"))
+        self.assertEqual(Decimal(data["LIABILITY"]), Decimal("-70"))
+

--- a/report/urls.py
+++ b/report/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.report_dashboard, name='report_dashboard'),
+    path("", views.report_dashboard, name="report_dashboard"),
+    path("financial-statement/", views.financial_statement, name="financial_statement"),
 ]

--- a/report/views.py
+++ b/report/views.py
@@ -1,7 +1,42 @@
+from datetime import date, datetime
+
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
+
+from .financial_statements import account_type_balances
 
 
 @require_http_methods(["GET"])
 def report_dashboard(request):
-    return render(request, 'report/dashboard.html')
+    return render(request, "report/dashboard.html")
+
+
+@require_http_methods(["GET"])
+def financial_statement(request):
+    """Return aggregated voucher entry totals grouped by account type.
+
+    The period can be specified via ``start``/``end`` query parameters (ISO
+    formatted) or a ``year`` parameter representing a financial year.
+    """
+
+    year = request.GET.get("year")
+    start = request.GET.get("start")
+    end = request.GET.get("end")
+
+    if year:
+        start_date = date(int(year), 1, 1)
+        end_date = date(int(year), 12, 31)
+    elif start and end:
+        start_date = datetime.fromisoformat(start).date()
+        end_date = datetime.fromisoformat(end).date()
+    else:
+        return JsonResponse(
+            {"detail": "Provide 'year' or both 'start' and 'end' parameters."},
+            status=400,
+        )
+
+    totals = account_type_balances(start_date=start_date, end_date=end_date)
+    # Convert Decimals to strings for JSON serialisation
+    data = {k: str(v) for k, v in totals.items()}
+    return JsonResponse(data)


### PR DESCRIPTION
## Summary
- add `account_type_balances` service to aggregate voucher entries by account type
- expose `/reports/financial-statement/` JSON endpoint for querying totals by date range or year
- test service and endpoint with hand-crafted vouchers

## Testing
- `python manage.py test`
- `python manage.py test report`


------
https://chatgpt.com/codex/tasks/task_e_68a500844af0832986292ea0a9197628