### PR TITLE
Add financial ratio utilities and API endpoints

### DIFF
--- a/report/ratios.py
+++ b/report/ratios.py
@@ -1,0 +1,57 @@
+from decimal import Decimal
+from django.db.models import Sum, F
+from voucher.models import VoucherEntry
+
+
+def _sum_entries(entries, account_type_name, positive="debit"):
+    """Return the summed balance for an account type.
+
+    Parameters
+    ----------
+    entries: QuerySet[VoucherEntry]
+        Entries to aggregate.
+    account_type_name: str
+        Name of the :class:`~voucher.models.AccountType` to filter on.
+    positive: str
+        Whether the natural positive side of the account is ``debit`` or ``credit``.
+    """
+    expr = F("debit") - F("credit") if positive == "debit" else F("credit") - F("debit")
+    return (
+        entries.filter(account__account_type__name=account_type_name).aggregate(total=Sum(expr))["total"]
+        or Decimal("0")
+    )
+
+
+def current_ratio(*, current_assets=None, current_liabilities=None, entries=None):
+    """Calculate the current ratio.
+
+    Either ``current_assets`` and ``current_liabilities`` can be provided directly,
+    or a queryset of :class:`~voucher.models.VoucherEntry` can be supplied via
+    ``entries`` to derive the values from underlying accounting data.
+    """
+    if entries is not None:
+        if current_assets is None:
+            current_assets = _sum_entries(entries, "ASSET", positive="debit")
+        if current_liabilities is None:
+            current_liabilities = _sum_entries(entries, "LIABILITY", positive="credit")
+    if not current_liabilities:
+        return None
+    return float(current_assets) / float(current_liabilities)
+
+
+def gross_profit_margin(*, gross_profit=None, revenue=None, entries=None):
+    """Calculate the gross profit margin.
+
+    Parameters can be supplied directly or derived from ``entries``. When using
+    ``entries``, all ``INCOME`` accounts are treated as revenue and all ``EXPENSE``
+    accounts as cost of goods sold.
+    """
+    if entries is not None:
+        if revenue is None:
+            revenue = _sum_entries(entries, "INCOME", positive="credit")
+        if gross_profit is None:
+            expenses = _sum_entries(entries, "EXPENSE", positive="debit")
+            gross_profit = revenue - expenses
+    if not revenue:
+        return None
+    return float(gross_profit) / float(revenue)

--- a/report/tests.py
+++ b/report/tests.py
@@ -1,3 +1,54 @@
+from datetime import date
 from django.test import TestCase
+from voucher.models import (
+    AccountType,
+    ChartOfAccount,
+    VoucherType,
+    Voucher,
+    VoucherEntry,
+)
+from user.models import CustomUser
+from .ratios import current_ratio, gross_profit_margin
 
-# Create your tests here.
+
+class RatioTests(TestCase):
+    def setUp(self):
+        asset_type = AccountType.objects.create(name="ASSET")
+        liability_type = AccountType.objects.create(name="LIABILITY")
+        income_type = AccountType.objects.create(name="INCOME")
+        expense_type = AccountType.objects.create(name="EXPENSE")
+
+        asset_acct = ChartOfAccount.objects.create(
+            name="Cash", code="A1", account_type=asset_type
+        )
+        liability_acct = ChartOfAccount.objects.create(
+            name="Payable", code="L1", account_type=liability_type
+        )
+        income_acct = ChartOfAccount.objects.create(
+            name="Sales", code="I1", account_type=income_type
+        )
+        expense_acct = ChartOfAccount.objects.create(
+            name="COGS", code="E1", account_type=expense_type
+        )
+
+        user = CustomUser.objects.create(email="test@example.com")
+        vtype, _ = VoucherType.objects.get_or_create(code="JV", defaults={"name": "Journal"})
+        voucher = Voucher.objects.create(
+            voucher_type=vtype,
+            date=date.today(),
+            amount=0,
+            narration="",
+            created_by=user,
+        )
+        VoucherEntry.objects.create(voucher=voucher, account=asset_acct, debit=2000, credit=0)
+        VoucherEntry.objects.create(voucher=voucher, account=liability_acct, debit=0, credit=1000)
+        VoucherEntry.objects.create(voucher=voucher, account=income_acct, debit=0, credit=5000)
+        VoucherEntry.objects.create(voucher=voucher, account=expense_acct, debit=3000, credit=0)
+
+    def test_current_ratio(self):
+        entries = VoucherEntry.objects.all()
+        self.assertAlmostEqual(current_ratio(entries=entries), 2.0)
+
+    def test_gross_profit_margin(self):
+        entries = VoucherEntry.objects.all()
+        self.assertAlmostEqual(gross_profit_margin(entries=entries), 0.4)

--- a/report/urls.py
+++ b/report/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.report_dashboard, name='report_dashboard'),
+    path('ratios/', views.financial_ratios, name='financial_ratios'),
 ]

--- a/report/views.py
+++ b/report/views.py
@@ -1,7 +1,21 @@
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from voucher.models import VoucherEntry
+from .ratios import current_ratio, gross_profit_margin
 
 
 @require_http_methods(["GET"])
 def report_dashboard(request):
     return render(request, 'report/dashboard.html')
+
+
+@api_view(["GET"])
+def financial_ratios(request):
+    entries = VoucherEntry.objects.all()
+    data = {
+        "currentRatio": current_ratio(entries=entries),
+        "grossProfitMargin": gross_profit_margin(entries=entries),
+    }
+    return Response(data)


### PR DESCRIPTION
## Summary
- add utility functions for current ratio and gross profit margin
- expose a `/report/ratios/` API returning current and gross profit metrics
- cover ratio calculations with unit tests

## Testing
- `python manage.py test report`

------
https://chatgpt.com/codex/tasks/task_e_68a500868c8083299a079f3b7d32a08f