### PR TITLE
Add management command to close financial year and reset balances

### DIFF
--- a/erp/test_settings.py
+++ b/erp/test_settings.py
@@ -10,6 +10,7 @@ MIGRATION_MODULES = {
     'hr': None,
     'expense': None,
     'report': None,
+    'finance': None,
     'user': None,
     'crm': None,
     'task': None,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = erp.test_settings
+testpaths = voucher
+python_files = tests.py test_*.py *_tests.py

--- a/voucher/conftest.py
+++ b/voucher/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "erp.test_settings")

--- a/voucher/management/commands/close_year.py
+++ b/voucher/management/commands/close_year.py
@@ -1,0 +1,103 @@
+from datetime import timedelta
+from decimal import Decimal
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Sum
+
+from voucher.models import (
+    AccountType,
+    ChartOfAccount,
+    FinancialYear,
+    Voucher,
+    VoucherEntry,
+    VoucherType,
+)
+
+
+class Command(BaseCommand):
+    """Close the active financial year and carry forward the balance."""
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "equity_account",
+            type=int,
+            help="ID of the equity account (e.g. retained earnings)",
+        )
+        parser.add_argument(
+            "--open-next",
+            action="store_true",
+            dest="open_next",
+            help="Open the next financial year",
+        )
+
+    def handle(self, *args, **options):
+        equity_account_id = options["equity_account"]
+        open_next = options["open_next"]
+
+        try:
+            year = FinancialYear.objects.get(is_closed=False)
+        except FinancialYear.DoesNotExist:  # pragma: no cover - guard clause
+            raise CommandError("No active financial year found")
+
+        equity_account = ChartOfAccount.objects.get(pk=equity_account_id)
+
+        income_type = AccountType.objects.get(name="INCOME")
+        expense_type = AccountType.objects.get(name="EXPENSE")
+
+        voucher_type, _ = VoucherType.objects.get_or_create(
+            code=VoucherType.JOURNAL, defaults={"name": "Journal"}
+        )
+
+        entries = []
+        net_income = Decimal("0")
+
+        accounts = ChartOfAccount.objects.filter(
+            account_type__in=[income_type, expense_type]
+        )
+        for account in accounts:
+            totals = VoucherEntry.objects.filter(
+                account=account,
+                voucher__date__range=(year.start_date, year.end_date),
+            ).aggregate(debit=Sum("debit"), credit=Sum("credit"))
+            debit = totals["debit"] or Decimal("0")
+            credit = totals["credit"] or Decimal("0")
+
+            if account.account_type_id == income_type.id:
+                balance = credit - debit
+                net_income += balance
+                if balance > 0:
+                    entries.append({"account": account, "debit": balance, "credit": Decimal("0")})
+                elif balance < 0:
+                    entries.append({"account": account, "credit": -balance, "debit": Decimal("0")})
+            else:  # expense account
+                balance = debit - credit
+                net_income -= balance
+                if balance > 0:
+                    entries.append({"account": account, "credit": balance, "debit": Decimal("0")})
+                elif balance < 0:
+                    entries.append({"account": account, "debit": -balance, "credit": Decimal("0")})
+
+        if net_income > 0:
+            entries.append({"account": equity_account, "credit": net_income, "debit": Decimal("0")})
+        elif net_income < 0:
+            entries.append({"account": equity_account, "debit": -net_income, "credit": Decimal("0")})
+
+        if entries:
+            Voucher.create_with_entries(
+                voucher_type=voucher_type,
+                date=year.end_date,
+                narration=f"Year end closing {year}",
+                created_by=None,
+                entries=entries,
+            )
+
+        year.is_closed = True
+        year.save()
+
+        if open_next:
+            duration = year.end_date - year.start_date
+            next_start = year.end_date + timedelta(days=1)
+            next_end = next_start + duration
+            FinancialYear.objects.create(start_date=next_start, end_date=next_end)
+
+        self.stdout.write(self.style.SUCCESS("Financial year closed"))

--- a/voucher/migrations/0004_financialyear.py
+++ b/voucher/migrations/0004_financialyear.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("voucher", "0003_add_journal_vouchertype"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="FinancialYear",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("start_date", models.DateField()),
+                ("end_date", models.DateField()),
+                ("is_closed", models.BooleanField(default=False)),
+            ],
+        ),
+    ]

--- a/voucher/models.py
+++ b/voucher/models.py
@@ -26,6 +26,17 @@ class ChartOfAccount(models.Model):
         return f"{self.code} - {self.name}"
 
 
+class FinancialYear(models.Model):
+    """Represents a range of dates for accounting purposes."""
+
+    start_date = models.DateField()
+    end_date = models.DateField()
+    is_closed = models.BooleanField(default=False)
+
+    def __str__(self):  # pragma: no cover - display helper
+        return f"{self.start_date} - {self.end_date}"
+
+
 class VoucherType(models.Model):
     """Lookup for categorising different kinds of vouchers."""
 

--- a/voucher/test_close_year.py
+++ b/voucher/test_close_year.py
@@ -1,0 +1,89 @@
+from datetime import date
+from decimal import Decimal
+
+from django.core.management import call_command
+from django.db.models import Sum
+from django.test import TestCase
+
+from voucher.models import (
+    AccountType,
+    ChartOfAccount,
+    FinancialYear,
+    Voucher,
+    VoucherEntry,
+    VoucherType,
+)
+
+
+class CloseYearCommandTests(TestCase):
+    def setUp(self):
+        self.asset = AccountType.objects.create(name="ASSET")
+        self.income = AccountType.objects.create(name="INCOME")
+        self.expense = AccountType.objects.create(name="EXPENSE")
+        self.equity = AccountType.objects.create(name="EQUITY")
+
+        self.cash = ChartOfAccount.objects.create(
+            name="Cash", code="CASH", account_type=self.asset
+        )
+        self.sales = ChartOfAccount.objects.create(
+            name="Sales", code="SALES", account_type=self.income
+        )
+        self.rent = ChartOfAccount.objects.create(
+            name="Rent", code="RENT", account_type=self.expense
+        )
+        self.retained = ChartOfAccount.objects.create(
+            name="Retained Earnings", code="RE", account_type=self.equity
+        )
+
+        self.jv, _ = VoucherType.objects.get_or_create(
+            code=VoucherType.JOURNAL, defaults={"name": "Journal"}
+        )
+
+        self.year = FinancialYear.objects.create(
+            start_date=date(2024, 1, 1), end_date=date(2024, 12, 31)
+        )
+
+        Voucher.create_with_entries(
+            voucher_type=self.jv,
+            date=date(2024, 6, 1),
+            narration="Sale",
+            created_by=None,
+            entries=[
+                {"account": self.cash, "debit": Decimal("100"), "credit": 0},
+                {"account": self.sales, "debit": 0, "credit": Decimal("100")},
+            ],
+        )
+        Voucher.create_with_entries(
+            voucher_type=self.jv,
+            date=date(2024, 6, 2),
+            narration="Rent",
+            created_by=None,
+            entries=[
+                {"account": self.rent, "debit": Decimal("40"), "credit": 0},
+                {"account": self.cash, "debit": 0, "credit": Decimal("40")},
+            ],
+        )
+
+    def balance(self, account):
+        totals = VoucherEntry.objects.filter(
+            account=account,
+            voucher__date__range=(self.year.start_date, self.year.end_date),
+        ).aggregate(debit=Sum("debit"), credit=Sum("credit"))
+        debit = totals["debit"] or Decimal("0")
+        credit = totals["credit"] or Decimal("0")
+        return debit, credit
+
+    def test_close_year_transfers_net_income(self):
+        call_command("close_year", self.retained.id)
+
+        self.year.refresh_from_db()
+        self.assertTrue(self.year.is_closed)
+
+        d, c = self.balance(self.sales)
+        self.assertEqual(d, c)
+
+        d, c = self.balance(self.rent)
+        self.assertEqual(d, c)
+
+        d, c = self.balance(self.retained)
+        self.assertEqual(c - d, Decimal("60"))


### PR DESCRIPTION
## Summary
- add `FinancialYear` model and command to transfer income/expense balances into retained earnings
- configure tests and add coverage for closing the year

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a500880f4483298da58022fe551599