### PR TITLE
Add order confirmation flow generating sale invoices

### DIFF
--- a/ecommerce/migrations/0002_order_sale_invoice.py
+++ b/ecommerce/migrations/0002_order_sale_invoice.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sale", "0004_alter_salereturnitem_net_amount"),
+        ("ecommerce", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="order",
+            name="sale_invoice",
+            field=models.OneToOneField(blank=True, null=True, on_delete=models.SET_NULL, to="sale.saleinvoice"),
+        ),
+    ]

--- a/ecommerce/models.py
+++ b/ecommerce/models.py
@@ -1,6 +1,7 @@
-from django.db import models
+from django.db import models, transaction
 
 from inventory.models import Party, Product
+from sale.models import SaleInvoice, SaleInvoiceItem
 
 
 class Order(models.Model):
@@ -14,9 +15,37 @@ class Order(models.Model):
     customer = models.ForeignKey(Party, on_delete=models.CASCADE, limit_choices_to={'party_type': 'customer'})
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="Pending")
     total_amount = models.DecimalField(max_digits=12, decimal_places=2)
+    sale_invoice = models.OneToOneField("sale.SaleInvoice", null=True, blank=True, on_delete=models.SET_NULL)
 
     def __str__(self):
         return self.order_no
+
+    def confirm(self, warehouse, payment_method):
+        with transaction.atomic():
+            invoice = SaleInvoice.objects.create(
+                invoice_no=self.order_no,
+                date=self.date,
+                customer=self.customer,
+                warehouse=warehouse,
+                total_amount=self.total_amount,
+                payment_method=payment_method,
+            )
+
+            for item in self.items.all():
+                SaleInvoiceItem.objects.create(
+                    invoice=invoice,
+                    product=item.product,
+                    quantity=item.quantity,
+                    rate=item.price,
+                    amount=item.amount,
+                    net_amount=item.amount,
+                )
+
+            self.status = "Confirmed"
+            self.sale_invoice = invoice
+            self.save(update_fields=["status", "sale_invoice"])
+
+        return invoice
 
 
 class OrderItem(models.Model):

--- a/ecommerce/tests.py
+++ b/ecommerce/tests.py
@@ -4,9 +4,11 @@ from rest_framework.test import APITestCase
 from django.contrib.auth import get_user_model
 
 from inventory.models import Party, Product
-from setting.models import Company, Distributor, Group, City, Area
+from setting.models import Company, Distributor, Group, City, Area, Branch, Warehouse
+from voucher.models import AccountType, ChartOfAccount
 
 from .models import Order
+from sale.models import SaleInvoice, SaleInvoiceItem
 
 
 class OrderAPITestCase(APITestCase):
@@ -17,6 +19,20 @@ class OrderAPITestCase(APITestCase):
 
         city = City.objects.create(name="Metropolis")
         area = Area.objects.create(name="Center", city=city)
+
+        asset = AccountType.objects.create(name="ASSET")
+        income = AccountType.objects.create(name="INCOME")
+        self.customer_account = ChartOfAccount.objects.create(
+            name="Customer", code="1000", account_type=asset
+        )
+        self.sales_account = ChartOfAccount.objects.create(
+            name="Sales", code="4000", account_type=income
+        )
+        branch = Branch.objects.create(name="Main", address="addr")
+        self.warehouse = Warehouse.objects.create(
+            name="W1", branch=branch, default_sales_account=self.sales_account
+        )
+
         self.customer = Party.objects.create(
             name="Cust",
             address="addr",
@@ -24,6 +40,7 @@ class OrderAPITestCase(APITestCase):
             party_type="customer",
             city=city,
             area=area,
+            chart_of_account=self.customer_account,
         )
 
         company = Company.objects.create(name="C1")
@@ -65,3 +82,41 @@ class OrderAPITestCase(APITestCase):
         order = Order.objects.first()
         self.assertEqual(order.order_no, "ORD-001")
         self.assertEqual(order.items.count(), 1)
+
+    def test_confirm_order_creates_invoice(self):
+        order_url = "/ecommerce/orders/"
+        order_data = {
+            "order_no": "ORD-002",
+            "date": date.today(),
+            "customer": self.customer.id,
+            "status": "Pending",
+            "total_amount": "10.00",
+            "items": [
+                {
+                    "product": self.product.id,
+                    "quantity": 1,
+                    "price": "10.00",
+                    "amount": "10.00",
+                }
+            ],
+        }
+        create_resp = self.client.post(order_url, order_data, format="json")
+        self.assertEqual(create_resp.status_code, 201)
+        order_id = create_resp.data["id"]
+
+        confirm_url = f"/ecommerce/orders/{order_id}/confirm/"
+        resp = self.client.post(
+            confirm_url,
+            {"warehouse": self.warehouse.id, "payment_method": "Cash"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        order = Order.objects.get(id=order_id)
+        self.assertEqual(order.status, "Confirmed")
+        self.assertIsNotNone(order.sale_invoice)
+        self.assertEqual(SaleInvoice.objects.count(), 1)
+        invoice = SaleInvoice.objects.first()
+        self.assertEqual(invoice.total_amount, order.total_amount)
+        self.assertEqual(SaleInvoiceItem.objects.count(), 1)
+        item = SaleInvoiceItem.objects.first()
+        self.assertEqual(item.amount, order.items.first().amount)

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -1,9 +1,22 @@
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from .models import Order
 from .serializers import OrderSerializer
+from sale.serializers import SaleInvoiceSerializer
+from setting.models import Warehouse
 
 
 class OrderViewSet(viewsets.ModelViewSet):
     queryset = Order.objects.all().prefetch_related("items")
     serializer_class = OrderSerializer
+
+    @action(detail=True, methods=["post"])
+    def confirm(self, request, pk=None):
+        order = self.get_object()
+        warehouse = Warehouse.objects.get(pk=request.data.get("warehouse"))
+        payment_method = request.data.get("payment_method")
+        invoice = order.confirm(warehouse, payment_method)
+        serializer = SaleInvoiceSerializer(invoice)
+        return Response(serializer.data)


### PR DESCRIPTION
## Summary
- link orders to generated sale invoices and items on confirmation
- expose confirm endpoint on OrderViewSet returning sale invoice data
- test order confirmation creates matching invoice and items

## Testing
- `python manage.py test ecommerce.tests -v 2` *(fails: no such table: finance_financialyear)*


------
https://chatgpt.com/codex/tasks/task_e_68a66e9e9c2883299f2fc038188d54e5