### PR TITLE
Confirm orders via admin

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -1,6 +1,21 @@
 from django.contrib import admin
+from django import forms
+
+from setting.models import Warehouse
+from sale.models import SaleInvoice
 
 from .models import Order, OrderItem
+
+
+class OrderAdminForm(forms.ModelForm):
+    warehouse = forms.ModelChoiceField(queryset=Warehouse.objects.all(), required=False)
+    payment_method = forms.ChoiceField(
+        choices=SaleInvoice.PAYMENT_CHOICES, required=False, initial="Cash"
+    )
+
+    class Meta:
+        model = Order
+        fields = "__all__"
 
 
 class OrderItemInline(admin.TabularInline):
@@ -10,5 +25,17 @@ class OrderItemInline(admin.TabularInline):
 
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
+    form = OrderAdminForm
     inlines = [OrderItemInline]
     list_display = ["order_no", "customer", "date", "status", "total_amount"]
+
+    def save_model(self, request, obj, form, change):
+        previous_status = None
+        if change:
+            previous_status = Order.objects.get(pk=obj.pk).status
+        super().save_model(request, obj, form, change)
+        if obj.status == "Confirmed" and previous_status != "Confirmed":
+            warehouse = form.cleaned_data.get("warehouse") or Warehouse.objects.first()
+            payment_method = form.cleaned_data.get("payment_method") or "Cash"
+            if warehouse:
+                obj.confirm(warehouse, payment_method)


### PR DESCRIPTION
## Summary
- allow admins to choose a warehouse and payment method when editing orders
- automatically confirm orders in admin when status transitions to Confirmed

## Testing
- `pytest` *(fails: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet)*
- `python manage.py test` *(fails: django.db.utils.OperationalError: no such table: finance_financialyear)*

------
https://chatgpt.com/codex/tasks/task_e_68a6730af2848329907c5d11f3c5f374