### PR TITLE
Add admin action to confirm orders

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -1,6 +1,10 @@
 from django.contrib import admin
+from django import forms
+from django.contrib.admin.helpers import ActionForm
 
 from .models import Order, OrderItem
+from setting.models import Warehouse
+from sale.models import SaleInvoice
 
 
 class OrderItemInline(admin.TabularInline):
@@ -12,3 +16,31 @@ class OrderItemInline(admin.TabularInline):
 class OrderAdmin(admin.ModelAdmin):
     inlines = [OrderItemInline]
     list_display = ["order_no", "customer", "date", "status", "total_amount"]
+    actions = ["confirm_orders"]
+
+    class ConfirmOrderActionForm(ActionForm):
+        warehouse = forms.ModelChoiceField(
+            queryset=Warehouse.objects.all(), required=False
+        )
+        payment_method = forms.ChoiceField(
+            choices=SaleInvoice.PAYMENT_CHOICES, required=False
+        )
+
+    action_form = ConfirmOrderActionForm
+
+    @admin.action(description="Confirm selected orders")
+    def confirm_orders(self, request, queryset):
+        form = self.action_form(request.POST)
+        if form.is_valid():
+            warehouse = (
+                form.cleaned_data.get("warehouse")
+                or Warehouse.objects.first()
+            )
+            payment_method = (
+                form.cleaned_data.get("payment_method")
+                or SaleInvoice.PAYMENT_CHOICES[0][0]
+            )
+            for order in queryset:
+                order.confirm(
+                    warehouse=warehouse, payment_method=payment_method
+                )


### PR DESCRIPTION
## Summary
- add `confirm_orders` action to `OrderAdmin` to bulk confirm orders
- allow warehouse and payment method selection with sensible defaults

## Testing
- `python manage.py test ecommerce -v 2` *(fails: no such table: finance_financialyear)*

------
https://chatgpt.com/codex/tasks/task_e_68a6730b6dbc83298261e947a6ad429e