### PR TITLE
Add customer order filtering endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ Point of Sale (POS) submissions reuse the existing sale invoice API at `/sales/i
 The `SaleInvoice` model automatically creates and links a `Voucher` when an invoice is saved, ensuring each POS-generated invoice has a corresponding accounting entry.
 
 A regression test at `sale/tests.py` verifies that a voucher is attached whenever an invoice is created via the API.
+
+## Ecommerce orders
+
+Retrieve all orders for a specific customer via:
+
+```
+GET /ecommerce/orders/customer/<customer_id>/
+```
+Optional query parameters `limit` and `offset` can be used for pagination, e.g.:
+
+```
+GET /ecommerce/orders/customer/<customer_id>/?limit=10&offset=0
+```
+
+The response includes pagination fields (`count`, `next`, `previous`) alongside the results.

--- a/ecommerce/serializers.py
+++ b/ecommerce/serializers.py
@@ -1,9 +1,18 @@
 from rest_framework import serializers
 
 from .models import Order, OrderItem
+from inventory.models import Product
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = ["id", "name"]
 
 
 class OrderItemSerializer(serializers.ModelSerializer):
+    product = serializers.PrimaryKeyRelatedField(queryset=Product.objects.all())
+
     class Meta:
         model = OrderItem
         fields = [
@@ -13,6 +22,11 @@ class OrderItemSerializer(serializers.ModelSerializer):
             "price",
             "amount",
         ]
+
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        rep["product"] = ProductSerializer(instance.product).data
+        return rep
 
 
 class OrderSerializer(serializers.ModelSerializer):

--- a/ecommerce/tests.py
+++ b/ecommerce/tests.py
@@ -120,3 +120,91 @@ class OrderAPITestCase(APITestCase):
         self.assertEqual(SaleInvoiceItem.objects.count(), 1)
         item = SaleInvoiceItem.objects.first()
         self.assertEqual(item.amount, order.items.first().amount)
+
+    def test_list_orders_by_customer(self):
+        order_url = "/ecommerce/orders/"
+        order_data = {
+            "order_no": "ORD-003",
+            "date": date.today(),
+            "customer": self.customer.id,
+            "status": "Pending",
+            "total_amount": "10.00",
+            "items": [
+                {
+                    "product": self.product.id,
+                    "quantity": 1,
+                    "price": "10.00",
+                    "amount": "10.00",
+                }
+            ],
+        }
+        self.client.post(order_url, order_data, format="json")
+
+        other_account = ChartOfAccount.objects.create(
+            name="Customer2", code="1001", account_type=self.customer_account.account_type
+        )
+        other_customer = Party.objects.create(
+            name="Cust2",
+            address="addr",
+            phone="456",
+            party_type="customer",
+            city=self.customer.city,
+            area=self.customer.area,
+            chart_of_account=other_account,
+        )
+        other_data = {
+            "order_no": "ORD-004",
+            "date": date.today(),
+            "customer": other_customer.id,
+            "status": "Pending",
+            "total_amount": "10.00",
+            "items": [
+                {
+                    "product": self.product.id,
+                    "quantity": 1,
+                    "price": "10.00",
+                    "amount": "10.00",
+                }
+            ],
+        }
+        self.client.post(order_url, other_data, format="json")
+
+        list_url = f"/ecommerce/orders/customer/{self.customer.id}/"
+        resp = self.client.get(list_url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["count"], 1)
+        self.assertEqual(len(resp.data["results"]), 1)
+        self.assertEqual(resp.data["results"][0]["customer"], self.customer.id)
+        item = resp.data["results"][0]["items"][0]
+        self.assertEqual(item["product"]["id"], self.product.id)
+        self.assertEqual(item["product"]["name"], self.product.name)
+
+    def test_list_orders_by_customer_with_pagination(self):
+        order_url = "/ecommerce/orders/"
+
+        # create 3 orders for the same customer
+        for idx in range(3):
+            data = {
+                "order_no": f"ORD-P{idx}",
+                "date": date.today(),
+                "customer": self.customer.id,
+                "status": "Pending",
+                "total_amount": "10.00",
+                "items": [
+                    {
+                        "product": self.product.id,
+                        "quantity": 1,
+                        "price": "10.00",
+                        "amount": "10.00",
+                    }
+                ],
+            }
+            self.client.post(order_url, data, format="json")
+
+        list_url = f"/ecommerce/orders/customer/{self.customer.id}/?limit=2&offset=1"
+        resp = self.client.get(list_url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["count"], 3)
+        self.assertEqual(len(resp.data["results"]), 2)
+        # ensure the first item corresponds to the second created order
+        self.assertEqual(resp.data["results"][0]["order_no"], "ORD-P1")

--- a/ecommerce/views.py
+++ b/ecommerce/views.py
@@ -12,6 +12,21 @@ class OrderViewSet(viewsets.ModelViewSet):
     queryset = Order.objects.all().prefetch_related("items")
     serializer_class = OrderSerializer
 
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="customer/(?P<customer_id>[^/.]+)",
+    )
+    def list_by_customer(self, request, customer_id=None):
+        queryset = self.queryset.filter(customer_id=customer_id)
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
     @action(detail=True, methods=["post"])
     def confirm(self, request, pk=None):
         order = self.get_object()


### PR DESCRIPTION
## Summary
- add `customer/<id>` action to OrderViewSet for filtering orders by customer
- document new ecommerce orders route
- test listing orders for a specific customer
- support `limit` and `offset` pagination on customer order listing
- include product details in customer order responses

## Testing
- `pytest ecommerce/tests.py` *(fails: django.db.utils.OperationalError: no such table: finance_financialyear)*

------
https://chatgpt.com/codex/tasks/task_e_68a68b1b3bec8329b7a0e555e0511b52