### PR TITLE
Refactor expense ledger handling

### DIFF
--- a/expense/admin.py
+++ b/expense/admin.py
@@ -33,6 +33,6 @@ class ExpenseCategoryAdmin(admin.ModelAdmin):
 
 @admin.register(Expense)
 class ExpenseAdmin(admin.ModelAdmin):
-    list_display = ("date", "category", "amount", "payment_account", "voucher")
-    readonly_fields = ("voucher",)
+    list_display = ("date", "category", "amount", "payment_account")
+    readonly_fields = ()
     actions = [print_invoice_pdf]

--- a/expense/ledger.py
+++ b/expense/ledger.py
@@ -1,0 +1,37 @@
+"""Helpers for posting expense ledger entries."""
+
+from voucher.models import VoucherType
+from utils.voucher import create_voucher_for_transaction
+
+
+def post_expense_ledger(
+    *,
+    date,
+    amount,
+    narration,
+    expense_account,
+    payment_account,
+    created_by=None,
+    branch=None,
+):
+    """Post ledger entries for an expense.
+
+    Creates a voucher (type ``EXP``) debiting the expense account and
+    crediting the payment account.
+    Returns the created :class:`voucher.models.Voucher`.
+    """
+
+    # Ensure expense voucher type exists
+    vt, _ = VoucherType.objects.get_or_create(code="EXP", defaults={"name": "Expense"})
+
+    return create_voucher_for_transaction(
+        voucher_type_code=vt.code,
+        date=date,
+        amount=amount,
+        narration=narration,
+        debit_account=expense_account,
+        credit_account=payment_account,
+        created_by=created_by,
+        branch=branch,
+    )
+

--- a/expense/migrations/0003_remove_expense_voucher.py
+++ b/expense/migrations/0003_remove_expense_voucher.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('expense', '0002_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='expense',
+            name='voucher',
+        ),
+    ]

--- a/expense/models.py
+++ b/expense/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 
-from voucher.models import ChartOfAccount, Voucher, VoucherType
-from utils.voucher import create_voucher_for_transaction
+from voucher.models import ChartOfAccount
+from .ledger import post_expense_ledger
 
 
 class ExpenseCategory(models.Model):
@@ -24,29 +24,19 @@ class Expense(models.Model):
     payment_account = models.ForeignKey(
         ChartOfAccount, on_delete=models.PROTECT, related_name="expense_payments"
     )
-    voucher = models.ForeignKey(Voucher, on_delete=models.SET_NULL, null=True, blank=True)
 
     def save(self, *args, **kwargs):
         is_new = self.pk is None
         super().save(*args, **kwargs)
 
-        if (is_new or not self.voucher) and self.category.chart_of_account and self.payment_account:
-            # Ensure voucher type for expenses exists
-            try:
-                VoucherType.objects.get(code="EXP")
-            except VoucherType.DoesNotExist:
-                VoucherType.objects.create(code="EXP", name="Expense")
-
-            voucher = create_voucher_for_transaction(
-                voucher_type_code="EXP",
+        if is_new and self.category.chart_of_account and self.payment_account:
+            post_expense_ledger(
                 date=self.date,
                 amount=self.amount,
                 narration=self.description or f"Expense for {self.category.name}",
-                debit_account=self.category.chart_of_account,
-                credit_account=self.payment_account,
+                expense_account=self.category.chart_of_account,
+                payment_account=self.payment_account,
                 created_by=getattr(self, "created_by", None),
                 branch=getattr(self, "branch", None),
             )
-            self.voucher = voucher
-            super().save(update_fields=["voucher"])
 

--- a/expense/tests.py
+++ b/expense/tests.py
@@ -1,10 +1,8 @@
 from datetime import date
 
-
-from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
-from voucher.models import AccountType, ChartOfAccount, VoucherType
+from voucher.models import AccountType, ChartOfAccount, VoucherType, Voucher
 from .models import ExpenseCategory, Expense
 from decimal import Decimal
 
@@ -41,14 +39,14 @@ class ExpenseTests(APITestCase):
         VoucherType.objects.create(code="EXP", name="Expense")
 
     def test_expense_creates_voucher_on_save(self):
-        expense = Expense.objects.create(
+        Expense.objects.create(
             date=date.today(),
             category=self.category,
             amount=100,
             description="Taxi",
             payment_account=self.cash_account,
         )
-        self.assertIsNotNone(expense.voucher)
+        self.assertEqual(Voucher.objects.count(), 1)
 
     def test_expense_create_api_invalid(self):
         response = self.client.post(
@@ -85,10 +83,11 @@ class ExpenseVoucherTests(TestCase):
             description="Stationery",
             payment_account=self.cash_account,
         )
-        self.assertIsNotNone(exp.voucher)
+        voucher = Voucher.objects.last()
+        self.assertIsNotNone(voucher)
         assert_ledger_entries(
             self,
-            exp.voucher,
+            voucher,
             [
                 (self.expense_account, Decimal("25"), Decimal("0")),
                 (self.cash_account, Decimal("0"), Decimal("25")),


### PR DESCRIPTION
## Summary
- remove voucher field from Expense and decouple model from voucher logic
- add helper to post expense ledger entries and update save method
- adjust admin and tests for new ledger posting

## Testing
- `python manage.py makemigrations expense --noinput` (warning: Field 'employee' on model 'attendance' not migrated)
- `pytest` (fails: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet)


------
https://chatgpt.com/codex/tasks/task_e_68b75449099c8329b226fcf17e5dcf76