### PR TITLE
Remove payroll voucher field and post ledger entries via helper

### DIFF
--- a/hr/serializers.py
+++ b/hr/serializers.py
@@ -156,6 +156,5 @@ class PayrollSlipSerializer(serializers.ModelSerializer):
             "leaves_paid",
             "deductions",
             "net_salary",
-            "voucher",
             "created_on",
         ]

--- a/hr/tests.py
+++ b/hr/tests.py
@@ -12,7 +12,7 @@ from django.test import SimpleTestCase, TestCase
 
 
 from setting.models import Company
-from voucher.models import AccountType, ChartOfAccount
+from voucher.models import AccountType, ChartOfAccount, Voucher
 from .models import Employee, LeaveRequest, PayrollSlip
 from .views import LeaveRequestViewSet
 
@@ -73,7 +73,7 @@ class LeaveRequestStatusAPITest(APITestCase):
         )
         self.assertEqual(resp.status_code, 400)
 
-class PayrollSlipVoucherTests(TestCase):
+class PayrollSlipLedgerTests(TestCase):
     def setUp(self):
         expense = AccountType.objects.create(name="EXPENSE")
         asset = AccountType.objects.create(name="ASSET")
@@ -90,7 +90,7 @@ class PayrollSlipVoucherTests(TestCase):
         )
         self.employee = Employee.objects.create(name="John", phone="123")
 
-    def test_voucher_linked_and_net_salary_calculated(self):
+    def test_ledger_created_and_net_salary_calculated(self):
         slip = PayrollSlip.objects.create(
             employee=self.employee,
             month=date(2024, 1, 1),
@@ -103,8 +103,8 @@ class PayrollSlipVoucherTests(TestCase):
         )
         slip.refresh_from_db()
         self.assertEqual(slip.net_salary, Decimal("2800"))
-        self.assertIsNotNone(slip.voucher)
-        voucher = slip.voucher
+        self.assertEqual(Voucher.objects.count(), 1)
+        voucher = Voucher.objects.first()
         entries = list(voucher.entries.all().order_by("id"))
         self.assertEqual(voucher.amount, Decimal("2800"))
         self.assertEqual(len(entries), 2)

--- a/utils/voucher.py
+++ b/utils/voucher.py
@@ -336,6 +336,49 @@ def post_composite_sales_voucher(
     return v
 
 
+def post_payroll_voucher(
+    *,
+    date,
+    amount,
+    payroll_expense_account,
+    payroll_payment_account,
+    narration,
+    created_by=None,
+    branch=None,
+    financial_year=None,
+):
+    """Post a payroll voucher.
+
+    DR payroll_expense_account
+    CR payroll_payment_account (cash/bank)
+    """
+    vt, _ = VoucherType.objects.get_or_create(code="PAY", defaults={"name": "Payroll"})
+    entries = [
+        {
+            "account": payroll_expense_account,
+            "debit": amount,
+            "credit": 0,
+            "remarks": "Payroll expense",
+        },
+        {
+            "account": payroll_payment_account,
+            "debit": 0,
+            "credit": amount,
+            "remarks": "Payroll payment",
+        },
+    ]
+    v = Voucher.create_with_entries(
+        voucher_type=vt,
+        date=date,
+        narration=narration,
+        created_by=created_by,
+        entries=entries,
+        branch=branch,
+        financial_year=financial_year,
+    )
+    return v
+
+
 def create_voucher_for_transaction(
     *,
     voucher_type_code,


### PR DESCRIPTION
## Summary
- remove PayrollSlip.voucher field and related voucher imports
- add `post_payroll_voucher` helper for payroll ledger posting
- use helper in PayrollSlip.save and update tests/serializers

## Testing
- `venv/bin/pytest hr/tests.py --ds=erp.test_sqlite_settings`

------
https://chatgpt.com/codex/tasks/task_e_68b7544d496c8329ae6705a85b1f31b0