### PR TITLE
Add Django Ledger integration

### DIFF
--- a/erp/settings.py
+++ b/erp/settings.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
     'pricing',
     'investor',
     'syncqueue',
+    'django_ledger',
     'corsheaders',
 
 
@@ -218,3 +219,8 @@ else:
 STATICFILES_DIRS = [
     BASE_DIR / "staticfilesDir",
 ]
+
+# Django Ledger configuration
+DJANGO_LEDGER_ORGANIZATION = "OKTTS"
+DJANGO_LEDGER_LEDGER_BASE = "ledger"
+DJANGO_LEDGER_CURRENCY = "USD"

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ urllib3==2.5.0
 webencodings==0.5.1
 xhtml2pdf==0.2.17
 pdfplumber
+django-ledger


### PR DESCRIPTION
## Summary
- include Django Ledger dependency
- enable Django Ledger app and default ledger settings

## Testing
- `python manage.py migrate django_ledger` *(fails: could not translate host name "db" to address: Name or service not known)*
- `python manage.py check`
- `pytest -q` *(fails: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.)*

------
https://chatgpt.com/codex/tasks/task_e_68b75aeb1e5c832986d5705fba2f84b7