### PR TITLE
Use django_ledger for payroll posting

### DIFF
--- a/erp/settings.py
+++ b/erp/settings.py
@@ -77,9 +77,7 @@ INSTALLED_APPS = [
     'expense',
     'report',
     'user',
-
-
-
+    'django_ledger',
     'crm',
     'task',
     'notification',

--- a/hr/migrations/0003_payroll_journal_entry.py
+++ b/hr/migrations/0003_payroll_journal_entry.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hr', '0002_initial'),
+        ('django_ledger', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='payrollslip',
+            name='journal_entry',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='django_ledger.journalentrymodel'),
+        ),
+    ]

--- a/hr/serializers.py
+++ b/hr/serializers.py
@@ -156,6 +156,6 @@ class PayrollSlipSerializer(serializers.ModelSerializer):
             "leaves_paid",
             "deductions",
             "net_salary",
-            "voucher",
+            "journal_entry",
             "created_on",
         ]

--- a/setting/migrations/0003_company_accounts_ledger.py
+++ b/setting/migrations/0003_company_accounts_ledger.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('setting', '0002_initial'),
+        ('django_ledger', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='company',
+            name='payroll_expense_account',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='payroll_expense_company', to='django_ledger.accountmodel'),
+        ),
+        migrations.AlterField(
+            model_name='company',
+            name='payroll_payment_account',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='payroll_payment_company', to='django_ledger.accountmodel'),
+        ),
+    ]

--- a/setting/models.py
+++ b/setting/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django_ledger.models.accounts import AccountModel
 
 # Create your models here.
 
@@ -20,14 +21,14 @@ class Area(models.Model):
 class Company(models.Model):
     name = models.CharField(max_length=100)
     payroll_expense_account = models.ForeignKey(
-        'voucher.ChartOfAccount',
+        AccountModel,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name='payroll_expense_company'
     )
     payroll_payment_account = models.ForeignKey(
-        'voucher.ChartOfAccount',
+        AccountModel,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,


### PR DESCRIPTION
## Summary
- Post payroll slips to django_ledger by debiting expense and crediting payment accounts
- Reference django_ledger accounts for company defaults
- Enable django_ledger app and adjust serializers/tests

## Testing
- `python manage.py test hr.tests.PayrollSlipLedgerTests` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68b760f6cb288329973fe040707e60e5